### PR TITLE
Fix cross-platform tilde substitution, simplify init

### DIFF
--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -80,7 +80,7 @@ component_ps1() {
   cwd=$(echo "$input" | jq -r '.workspace.current_dir // empty')
   local user_host="$(whoami)@$(hostname -s)"
   if [ -n "$cwd" ]; then
-    cwd="${cwd/#$HOME/\~}"
+    cwd="${cwd/#"$HOME"/\~}"
     printf '\033[1;32m%s\033[0m:\033[1;34m%s\033[0m' "$user_host" "$cwd"
   else
     printf '\033[1;32m%s\033[0m' "$user_host"
@@ -119,7 +119,7 @@ component_cwd() {
   local cwd
   cwd=$(echo "$input" | jq -r '.workspace.current_dir // empty')
   [ -z "$cwd" ] && return
-  cwd="${cwd/#$HOME/\~}"
+  cwd="${cwd/#"$HOME"/\~}"
   printf '\033[1;34m%s\033[0m' "$cwd"
 }
 

--- a/plugins/redline/skills/init/SKILL.md
+++ b/plugins/redline/skills/init/SKILL.md
@@ -50,15 +50,4 @@ Use the Edit tool to update `~/.claude/settings.json`. If a `statusLine` key alr
 
 ## 4. Confirm
 
-Tell the user setup is complete and the statusline will appear after the next assistant response. If they want to customize the layout, they can create `~/.claude/statusline-config.json`:
-
-```json
-{
-  "lines": [
-    ["ps1", "git"],
-    ["model", "ctx_bar", "5h_bar", "7d_bar", "cost", "lines"]
-  ]
-}
-```
-
-Available components: `ps1`, `git`, `model`, `ctx_bar`, `ctx_short`, `5h_bar`, `5h_short`, `7d_bar`, `7d_short`, `cost`, `lines`.
+Tell the user setup is complete and the statusline will appear after the next assistant response. To customize the layout, run `/redline:config`.


### PR DESCRIPTION
## Summary
- Quote `$HOME` in bash parameter substitution to fix `\~` showing on macOS while keeping Linux working
- Simplify `/redline:init` closing message to point to `/redline:config` instead of dumping raw JSON

## Test plan
- [ ] Verify `~` shows correctly on macOS (no backslash)
- [ ] Verify `~` shows correctly on Linux (no full path)
- [ ] Run `/redline:init` and confirm it mentions `/redline:config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)