### PR TITLE
fix(redline): tilde substitution shows literal backslash on macOS

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -80,7 +80,7 @@ component_ps1() {
   cwd=$(echo "$input" | jq -r '.workspace.current_dir // empty')
   local user_host="$(whoami)@$(hostname -s)"
   if [ -n "$cwd" ]; then
-    cwd="${cwd/#"$HOME"/\~}"
+    _tilde='~'; cwd="${cwd/#"$HOME"/$_tilde}"
     printf '\033[1;32m%s\033[0m:\033[1;34m%s\033[0m' "$user_host" "$cwd"
   else
     printf '\033[1;32m%s\033[0m' "$user_host"
@@ -119,7 +119,7 @@ component_cwd() {
   local cwd
   cwd=$(echo "$input" | jq -r '.workspace.current_dir // empty')
   [ -z "$cwd" ] && return
-  cwd="${cwd/#"$HOME"/\~}"
+  _tilde='~'; cwd="${cwd/#"$HOME"/$_tilde}"
   printf '\033[1;34m%s\033[0m' "$cwd"
 }
 


### PR DESCRIPTION
## Summary
- Fix `\~` in bash parameter substitution producing literal `\~` on macOS (and `'~'` quoting also failing)
- Use a `_tilde` variable to sidestep both tilde expansion (Linux) and backslash escaping (macOS)
- Bump redline version to 1.0.1

## Test plan
- [ ] Verify statusline shows `~/dev` (not `\~/dev` or `'~'/dev`) on macOS
- [ ] Verify same on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)