### PR TITLE
fix(redline): resolve version by semver, drop symlink

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/scripts/redline-wrapper.sh
+++ b/plugins/redline/scripts/redline-wrapper.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-link="$HOME/.claude/redline-statusline.sh"
-if ! bash "$link" 2>/dev/null; then
-  target=$(ls -1t "$HOME/.claude/plugins/cache/allixsenos/redline"/*/scripts/statusline.sh 2>/dev/null | head -1)
-  [ -n "$target" ] && ln -sf "$target" "$link" && exec bash "$link"
-fi
+base="$HOME/.claude/plugins/cache/allixsenos/redline"
+target=$(ls -1d "$base"/*/scripts/statusline.sh 2>/dev/null | sort -t/ -k9 -V | tail -1)
+[ -n "$target" ] && exec bash "$target"

--- a/plugins/redline/skills/init/SKILL.md
+++ b/plugins/redline/skills/init/SKILL.md
@@ -3,29 +3,17 @@ name: init
 description: |
   Initial setup for the redline statusline plugin. Use when the user says
   /redline:init, "set up redline", or "install redline statusline". Creates
-  the wrapper script, symlink, and statusLine setting. Run once after install.
+  the wrapper script and statusLine setting. Run once after install.
 ---
 
 # Redline Setup
 
 Install the redline statusline by running these steps:
 
-## 1. Create the symlink to the current plugin version
+## 1. Copy the wrapper script to a stable location
 
 ```bash
-target=$(ls -1t "$HOME/.claude/plugins/cache/allixsenos/redline"/*/scripts/statusline.sh 2>/dev/null | head -1)
-if [ -n "$target" ]; then
-  ln -sf "$target" "$HOME/.claude/redline-statusline.sh"
-  echo "Symlinked: $HOME/.claude/redline-statusline.sh -> $target"
-else
-  echo "ERROR: redline plugin not found in cache. Is it installed?"
-fi
-```
-
-## 2. Copy the wrapper script to a stable location
-
-```bash
-wrapper_src=$(ls -1t "$HOME/.claude/plugins/cache/allixsenos/redline"/*/scripts/redline-wrapper.sh 2>/dev/null | head -1)
+wrapper_src=$(ls -1d "$HOME/.claude/plugins/cache/allixsenos/redline"/*/scripts/redline-wrapper.sh 2>/dev/null | sort -t/ -k9 -V | tail -1)
 if [ -n "$wrapper_src" ]; then
   cp "$wrapper_src" "$HOME/.claude/redline-wrapper.sh"
   chmod +x "$HOME/.claude/redline-wrapper.sh"
@@ -35,7 +23,7 @@ else
 fi
 ```
 
-## 3. Set the statusLine in settings.json
+## 2. Set the statusLine in settings.json
 
 Read `~/.claude/settings.json`, set `statusLine` to:
 
@@ -48,6 +36,6 @@ Read `~/.claude/settings.json`, set `statusLine` to:
 
 Use the Edit tool to update `~/.claude/settings.json`. If a `statusLine` key already exists, replace it. If not, add it.
 
-## 4. Confirm
+## 3. Confirm
 
 Tell the user setup is complete and the statusline will appear after the next assistant response. To customize the layout, run `/redline:config`.


### PR DESCRIPTION
## Summary
- Wrapper now uses `sort -V` to find the highest semver cache directory instead of relying on a symlink + `ls -1t`
- Removes the symlink step from init — no longer needed
- Fixes stale version after plugin updates where old cache dir has newer mtime

Bumps redline to 1.0.2.

## Test plan
- [ ] `/plugin` to update, verify 1.0.2 pulls
- [ ] Statusline resolves to latest version without running `/redline:init`
- [ ] Clean install via `/redline:init` still works (just wrapper copy + settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)