### PR TITLE
docs: per-skill READMEs with install instructions

### DIFF
--- a/skills/linkedin-data-portability/README.md
+++ b/skills/linkedin-data-portability/README.md
@@ -1,0 +1,41 @@
+# linkedin-data-portability
+
+Export LinkedIn member data (connections, profile, posts, messages, job applications, and 50+ other data domains) via the EU DMA Data Portability API.
+
+## Install
+
+```
+npx skills add allixsenos/claude-plugins --skill linkedin-data-portability
+```
+
+Or via the plugin marketplace (installs all plugins and skills):
+
+```
+/plugin marketplace add allixsenos/claude-plugins
+```
+
+## Requirements
+
+- LinkedIn account located in the EEA or Switzerland (DMA regulation)
+- LinkedIn Developer Application with **Member Data Portability API (Member)** access
+- `LINKEDIN_DMA_TOKEN` environment variable set with a valid OAuth access token
+
+## Setup
+
+1. Create a dev app at https://developer.linkedin.com/ using the [default company page](https://www.linkedin.com/company/member-data-portability-member-default-company)
+2. Request access to **Member Data Portability API (Member)** in the Products tab
+3. Generate an access token via **Docs and tools > OAuth Token Tools** with scope `r_dma_portability_self_serve`
+4. Set `LINKEDIN_DMA_TOKEN` in your environment
+
+## Usage
+
+Ask Claude to work with your LinkedIn data:
+
+- "pull my LinkedIn connections"
+- "export my LinkedIn profile"
+- "download my LinkedIn messages"
+- "analyze my LinkedIn network by company and role"
+
+## Available data
+
+50+ domains including: connections, profile, positions, education, skills, inbox, posts, comments, reactions, job applications, endorsements, recommendations, and more. See [references/snapshot-domains.md](references/snapshot-domains.md) for the full list.

--- a/skills/nano-banana/README.md
+++ b/skills/nano-banana/README.md
@@ -1,0 +1,27 @@
+# nano-banana
+
+Generate and edit images using the Gemini API (Nano Banana models) directly from Claude Code. Supports blog heroes, thumbnails, icons, diagrams, illustrations, photos, and any visual content. Arbitrary aspect ratios, multiple resolutions, and three model tiers.
+
+## Install
+
+```
+npx skills add allixsenos/claude-plugins --skill nano-banana
+```
+
+Or via the plugin marketplace (installs all plugins and skills):
+
+```
+/plugin marketplace add allixsenos/claude-plugins
+```
+
+## Requirements
+
+- `GEMINI_API_KEY` environment variable set
+
+## Usage
+
+Just ask Claude to create an image:
+
+- "generate a hero image for my blog post about database security"
+- "create a dark tech diagram showing a proxy architecture"
+- "edit this image to remove the background"

--- a/skills/openrouter-imagegen/README.md
+++ b/skills/openrouter-imagegen/README.md
@@ -1,0 +1,27 @@
+# openrouter-imagegen
+
+Generate and edit images using OpenRouter's unified API. Supports Google Nano Banana, OpenAI GPT-5 Image, FLUX.2, Sourceful Riverflow, and any future image models OpenRouter adds. Discovers available models at runtime.
+
+## Install
+
+```
+npx skills add allixsenos/claude-plugins --skill openrouter-imagegen
+```
+
+Or via the plugin marketplace (installs all plugins and skills):
+
+```
+/plugin marketplace add allixsenos/claude-plugins
+```
+
+## Requirements
+
+- `OPENROUTER_API_KEY` environment variable set
+
+## Usage
+
+Just ask Claude to create an image:
+
+- "generate an image of a mountain landscape using FLUX"
+- "create a logo using GPT-5 Image"
+- "what image models are available on OpenRouter?"


### PR DESCRIPTION
## Summary

- Added README.md to each standalone skill (nano-banana, openrouter-imagegen, linkedin-data-portability)
- Each README has: description, install command, requirements, and usage examples
- Git-governor and redline already had READMEs

Lets you link people directly to e.g. `skills/linkedin-data-portability/` and they get install instructions right there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)