### PR TITLE
fix: clockwork output format (v1.0.1)

### DIFF
--- a/plugins/clockwork/.claude-plugin/plugin.json
+++ b/plugins/clockwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clockwork",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Periodic time injection so Claude knows what day and time it is",
   "author": {
     "name": "Luka Kladaric",

--- a/plugins/clockwork/hooks/clockwork.sh
+++ b/plugins/clockwork/hooks/clockwork.sh
@@ -13,5 +13,6 @@ DIFF=$((NOW - LAST))
 if [ "$DIFF" -ge "$INTERVAL" ]; then
   echo "$NOW" > "$STAMP_FILE"
   TIME=$(date '+%A, %Y-%m-%d %H:%M %Z')
-  echo "{\"hookSpecificOutput\":{\"claudeOutput\":\"Current time: ${TIME}\"}}"
+  echo "Current time: ${TIME} (allixsenos/clockwork)"
 fi
+exit 0


### PR DESCRIPTION
## Summary

- Fix context injection: `hookSpecificOutput.claudeOutput` doesn't exist as a valid hook output field
- Use plain text stdout on exit 0 — the correct way to inject context from a `UserPromptSubmit` hook
- Add `(allixsenos/clockwork)` suffix for attribution in context
- Add explicit `exit 0`
- Bump version to 1.0.1

## Test plan

- [ ] Install plugin, `/reload-plugins`
- [ ] Wait 10+ minutes between messages (or `rm /tmp/claude-clockwork.stamp`)
- [ ] Verify `Current time: ... (allixsenos/clockwork)` appears in Claude's context

🤖 Generated with [Claude Code](https://claude.com/claude-code)