### PR TITLE
feat: per-session stamp file for clockwork (v1.1.0)

### DIFF
--- a/plugins/clockwork/.claude-plugin/plugin.json
+++ b/plugins/clockwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clockwork",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Periodic time injection so Claude knows what day and time it is",
   "author": {
     "name": "Luka Kladaric",

--- a/plugins/clockwork/hooks/clockwork.sh
+++ b/plugins/clockwork/hooks/clockwork.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # Clockwork — inject current time into Claude's context every 10 minutes.
 # Prevents temporal disorientation in long sessions.
+# Per-session stamp file so multiple sessions each get their own clock.
 
-STAMP_FILE="/tmp/claude-clockwork.stamp"
+INPUT=$(cat)
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+SESSION_ID="${SESSION_ID:-no-session-id}"
+
+STAMP_FILE="/tmp/claude-clockwork-${SESSION_ID}.stamp"
 INTERVAL=600 # 10 minutes
 
 NOW=$(date +%s)


### PR DESCRIPTION
## Summary

- Read `session_id` from hook stdin JSON to create per-session stamp files (`/tmp/claude-clockwork-{session_id}.stamp`)
- Multiple concurrent sessions each get their own 10-minute clock instead of one session blocking others
- Falls back to `no-session-id` if jq fails or field is missing
- Bump version to 1.1.0

## Test plan

- [ ] Run two Claude Code sessions simultaneously
- [ ] `rm /tmp/claude-clockwork-*.stamp` to reset
- [ ] Verify both sessions get time injections independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)