### PR TITLE
feat(redline): update checker + changelog skill (v1.1.0)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -17,6 +17,7 @@ The init skill creates a version-resilient wrapper and configures your statusLin
 
 - `/redline:init` — one-time setup after install
 - `/redline:config` — interactively change the layout
+- `/redline:changelog` — show recent Claude Code release notes
 
 ## Features
 
@@ -73,5 +74,6 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 | `7d_short` | 7-day rate limit as colored text in brackets + reset countdown |
 | `cost` | Session cost in yellow (e.g. `$0.42`) |
 | `lines` | Lines added (green) and removed (red) |
+| `update` | Shows bold yellow `↑ X.Y.Z` when a newer Claude Code version is available. Checks npm at most once every 4 hours (cached in `/tmp/redline-claude-version`). Silent when up to date. |
 
 Components can be placed on any line in any order. Omit a component to disable it entirely — no work is done for components not in the config.

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -231,6 +231,44 @@ component_lines() {
   [ -n "$delta" ] && printf '%b' "$delta"
 }
 
+component_update() {
+  local cache="/tmp/redline-claude-version"
+  local ttl=14400  # 4 hours in seconds
+  local now latest cached_at=0
+
+  now=$(date +%s)
+
+  # Read cache
+  if [ -f "$cache" ]; then
+    cached_at=$(sed -n '1p' "$cache")
+    latest=$(sed -n '2p' "$cache")
+  fi
+
+  # Refresh if stale or empty
+  if [ $((now - cached_at)) -ge $ttl ] || [ -z "$latest" ]; then
+    local fetched
+    fetched=$(npm view @anthropic-ai/claude-code version 2>/dev/null)
+    if [ -n "$fetched" ]; then
+      latest="$fetched"
+      printf '%s\n%s\n' "$now" "$latest" > "$cache"
+    fi
+  fi
+
+  [ -z "$latest" ] && return
+
+  # Get running version
+  local current
+  current=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  [ -z "$current" ] && return
+
+  # Compare: if latest > current, show upgrade prompt
+  local newer
+  newer=$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -1)
+  if [ "$newer" = "$latest" ] && [ "$latest" != "$current" ]; then
+    printf '\033[1;33m↑ claude code %s available\033[0m' "$latest"
+  fi
+}
+
 # --- Render a line from config ---
 
 render_line() {

--- a/plugins/redline/skills/changelog/SKILL.md
+++ b/plugins/redline/skills/changelog/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: changelog
+description: |
+  Show the Claude Code changelog. Use when the user says /redline:changelog,
+  "show changelog", "what's new in Claude Code", or "check Claude Code updates".
+---
+
+# Claude Code Changelog
+
+## Steps
+
+1. Run these two commands in parallel:
+   - Get installed version: `claude --version`
+   - Get latest version: `npm view @anthropic-ai/claude-code version`
+
+2. Fetch recent releases from GitHub:
+   ```bash
+   gh release list --repo anthropics/claude-code --limit 10
+   ```
+
+3. If the installed version is behind the latest, highlight that an update is available and show how to update:
+   ```bash
+   npm update -g @anthropic-ai/claude-code
+   ```
+
+4. Show the release notes for releases newer than the currently installed version. For each release, use:
+   ```bash
+   gh release view <tag> --repo anthropics/claude-code
+   ```
+
+   Present the output in a clean, readable format — version as a header, body as-is.
+
+5. If already on the latest version, say so and show notes for the most recent 2-3 releases anyway.

--- a/plugins/redline/skills/config/SKILL.md
+++ b/plugins/redline/skills/config/SKILL.md
@@ -61,6 +61,9 @@ Meters (bar = visual bar, short = compact text):
 Stats:
   cost         session cost                  $0.42
   lines        lines changed                 +156 -23
+
+Updates:
+  update       new version available          ↑ 2.2.0
 ```
 
 Note: reset countdowns (like `3h12m`) only appear when usage >= `show_reset_at`.


### PR DESCRIPTION
## Summary

- New `update` statusline component that checks npm for newer Claude Code versions every 4h (cached in `/tmp/redline-claude-version`), shows bold yellow `↑ claude code X.Y.Z available` when outdated, silent when current
- New `/redline:changelog` skill that fetches installed vs latest version and shows release notes via `gh release`
- Documented in README and config skill dashboard
- Bumped to 1.1.0

## Test plan

- [ ] Add `update` to statusline config, fake `/tmp/redline-claude-version` with a future version — verify indicator appears
- [ ] Verify indicator disappears when versions match
- [ ] Verify npm is not called when cache is fresh (<4h)
- [ ] Run `/redline:changelog` — verify it shows version comparison and release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)