### PR TITLE
fix(redline): include update in default config and docs

### DIFF
--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -41,7 +41,7 @@ Create `~/.claude/statusline-config.json` or use `/redline:config`:
 {
   "show_reset_at": 70,
   "lines": [
-    ["ps1", "git"],
+    ["ps1", "git", "update"],
     ["model", "ctx_short", "5h_short", "7d_short", "cost", "lines"]
   ]
 }

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -8,7 +8,7 @@ CONFIG_FILE="${CLAUDE_STATUSLINE_CONFIG:-$HOME/.claude/statusline-config.json}"
 if [ -f "$CONFIG_FILE" ]; then
   config=$(cat "$CONFIG_FILE")
 else
-  config='{"lines":[["ps1","git"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]}'
+  config='{"lines":[["ps1","git","update"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]}'
 fi
 
 # Config: threshold for showing reset countdown (default 70%)

--- a/plugins/redline/skills/config/SKILL.md
+++ b/plugins/redline/skills/config/SKILL.md
@@ -15,7 +15,7 @@ Interactive configuration for the redline statusline.
 
 Read `~/.claude/statusline-config.json` if it exists. If not, note the defaults:
 - `show_reset_at`: 70
-- `lines`: `[["ps1","git"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]`
+- `lines`: `[["ps1","git","update"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]`
 
 ## Step 2: Show the dashboard
 
@@ -23,11 +23,11 @@ Present the current layout with a monochrome ASCII preview of what each line loo
 
 ```
 Current layout:
-  Line 1: ps1, git
+  Line 1: ps1, git, update
   Line 2: model, ctx_bar, 5h_bar, 7d_bar, cost, lines
 
 Preview:
-  rmbug@veles:~/dev  main SM
+  rmbug@veles:~/dev  main SM  ↑ claude code 2.2.0 available
   Claude Opus 4.6  ctx [####8%....] 5h [###27%....] 3h12m  7d [#12%......] 5d4h  $0.42  +156 -23
 
 Settings:


### PR DESCRIPTION
## Summary

- Add `update` to the default statusline layout in `statusline.sh`
- Update config skill defaults and preview to include `update`
- Update README config example to include `update`

These were in follow-up commits on #15 but missed the squash merge.

## Test plan

- [ ] Fresh install (no `~/.claude/statusline-config.json`) shows `update` on line 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)