### PR TITLE
fix(clockwork): change attribution tag to "clockwork plugin" (v1.1.1)

### DIFF
--- a/plugins/clockwork/.claude-plugin/plugin.json
+++ b/plugins/clockwork/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clockwork",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Periodic time injection so Claude knows what day and time it is",
   "author": {
     "name": "Luka Kladaric",

--- a/plugins/clockwork/hooks/clockwork.sh
+++ b/plugins/clockwork/hooks/clockwork.sh
@@ -18,6 +18,8 @@ DIFF=$((NOW - LAST))
 if [ "$DIFF" -ge "$INTERVAL" ]; then
   echo "$NOW" > "$STAMP_FILE"
   TIME=$(date '+%A, %Y-%m-%d %H:%M %Z')
-  echo "Current time: ${TIME} (allixsenos/clockwork)"
+  # Tag identifies the source of this injection so the user (and Claude) can
+  # tell where it came from weeks later, without burning extra context tokens.
+  echo "Current time: ${TIME} (clockwork plugin)"
 fi
 exit 0


### PR DESCRIPTION
## Summary

- Change time injection tag from `(allixsenos/clockwork)` to `(clockwork plugin)`
- Add source comment explaining why the tag exists

The tag helps users trace where the injected line comes from after weeks of use. The previous wording looked like self-promotion rather than provenance — this makes the intent clearer.

Ref: hesreallyhim/awesome-claude-code#1546

## Test plan

- [ ] Run a session with clockwork installed, verify output reads `Current time: ... (clockwork plugin)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)