### PR TITLE
feat(redline): in-bar reset marker + burn indicator + rename init to setup (v1.2.0)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -8,14 +8,14 @@ Configurable statusline for Claude Code with progress bars, git info, cost track
 /plugin marketplace add allixsenos/claude-plugins
 /plugin install redline@allixsenos
 /reload-plugins
-/redline:init
+/redline:setup
 ```
 
-The init skill creates a version-resilient wrapper and configures your statusLine setting automatically.
+The setup skill creates a version-resilient wrapper and configures your statusLine setting automatically.
 
 ## Skills
 
-- `/redline:init` — one-time setup after install
+- `/redline:setup` — one-time setup after install
 - `/redline:config` — interactively change the layout
 - `/redline:changelog` — show recent Claude Code release notes
 

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -25,10 +25,13 @@ The init skill creates a version-resilient wrapper and configures your statusLin
 - Git branch + compact status flags (S=staged, M=modified, ?=untracked)
 - Model name display
 - Progress bars for context window, 5h session limit, and 7d weekly limit
-  - Percentage rendered inline inside the bar
   - Color thresholds: green < 60%, yellow >= 60%, red >= 80%
-- Short text variants with dark grey brackets (e.g. `[5h 42%]`)
-- Rate limit reset countdown (e.g. `2h31m`) — shown when usage exceeds threshold
+- Rate-limit bars include an in-bar `|` marker showing how far through the
+  window you are — usage fill past the marker = burning faster than real time
+- Short variants with dark grey brackets (e.g. `[5h 42%]`) flag burning pace
+  with a bright red `↑` inside the brackets
+- Rate limit reset countdown (e.g. `4h`, `5d`) rounded up to the coarsest
+  nonzero unit
 - Session cost and lines changed (+/-)
 - Fully configurable layout via JSON
 - Any number of output lines
@@ -39,7 +42,8 @@ Create `~/.claude/statusline-config.json` or use `/redline:config`:
 
 ```json
 {
-  "show_reset_at": 70,
+  "show_reset_at": 0,
+  "burn_threshold": 10,
   "lines": [
     ["ps1", "git", "update"],
     ["model", "ctx_short", "5h_short", "7d_short", "cost", "lines"]
@@ -53,7 +57,8 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `show_reset_at` | `70` | Show rate limit reset countdown when usage >= this %. `0` = always, `100` = never. |
+| `show_reset_at` | `0` | Show rate limit reset countdown when usage >= this %. `0` = always, `100` = never. |
+| `burn_threshold` | `10` | Percentage-point gap above elapsed time that triggers the `↑` burn icon in `5h_short`/`7d_short`. Only fires once the window is at least 20% elapsed. |
 
 ### Available components
 
@@ -68,10 +73,10 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 | `model` | Cyan model display name |
 | `ctx_bar` | Context window usage as a 10-step progress bar |
 | `ctx_short` | Context window usage as colored text in brackets |
-| `5h_bar` | 5-hour session rate limit as a progress bar + reset countdown |
-| `5h_short` | 5-hour rate limit as colored text in brackets + reset countdown |
-| `7d_bar` | 7-day weekly rate limit as a progress bar + reset countdown |
-| `7d_short` | 7-day rate limit as colored text in brackets + reset countdown |
+| `5h_bar` | 5-hour rate limit: `5h NN% [bar\|with\|marker] countdown`. `\|` shows elapsed-time position |
+| `5h_short` | 5-hour rate limit as `[5h NN%]` with `↑` inside when burning hot + countdown |
+| `7d_bar` | 7-day rate limit: `7d NN% [bar\|with\|marker] countdown` |
+| `7d_short` | 7-day rate limit as `[7d NN%]` with `↑` inside when burning hot + countdown |
 | `cost` | Session cost in yellow (e.g. `$0.42`) |
 | `lines` | Lines added (green) and removed (red) |
 | `update` | Shows bold yellow `↑ X.Y.Z` when a newer Claude Code version is available. Checks npm at most once every 4 hours (cached in `/tmp/redline-claude-version`). Silent when up to date. |

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -11,8 +11,20 @@ else
   config='{"lines":[["ps1","git","update"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]}'
 fi
 
-# Config: threshold for showing reset countdown (default 70%)
-show_reset_at=$(echo "$config" | jq -r '.show_reset_at // 70')
+# Config: threshold for showing reset countdown (default 0 = always show)
+show_reset_at=$(echo "$config" | jq -r '.show_reset_at // 0')
+
+# Config: percentage-point gap above elapsed time to flag as "burning hot"
+# in short meter variants (default 10). The flag only fires once elapsed >= 20%
+# to avoid false alarms right after a window resets.
+burn_threshold=$(echo "$config" | jq -r '.burn_threshold // 10')
+
+# Hardcoded window durations in seconds. The statusline JSON only exposes
+# used_percentage and resets_at per window (see code.claude.com/docs/en/statusline),
+# so the window size itself has to be hardcoded. If Anthropic ever changes tier
+# durations or introduces new windows, these constants go stale silently.
+WINDOW_5H_SECS=18000
+WINDOW_7D_SECS=604800
 
 # Helper: render a 10-step progress bar with percentage inside
 make_bar() {
@@ -130,20 +142,34 @@ component_model() {
   printf '\033[36m%s\033[0m' "$model"
 }
 
-# Helper: format seconds until reset as compact duration (e.g. "2h31m", "4d12h")
+# Helper: format seconds until reset as the coarsest nonzero unit, rounded up.
+# Examples: 4h30m -> 5h, 4h15m -> 5h, 4h exactly -> 4h, 3d15h -> 4d, 45s -> 1m.
 format_remaining() {
   local secs="$1"
   [ "$secs" -le 0 ] && echo "now" && return
-  local days=$((secs / 86400))
-  local hours=$(((secs % 86400) / 3600))
-  local mins=$(((secs % 3600) / 60))
-  if [ "$days" -gt 0 ]; then
-    printf '%dd%dh' "$days" "$hours"
-  elif [ "$hours" -gt 0 ]; then
-    printf '%dh%dm' "$hours" "$mins"
+  if [ "$secs" -ge 86400 ]; then
+    printf '%dd' "$(( (secs + 86399) / 86400 ))"
+  elif [ "$secs" -ge 3600 ]; then
+    printf '%dh' "$(( (secs + 3599) / 3600 ))"
   else
-    printf '%dm' "$mins"
+    printf '%dm' "$(( (secs + 59) / 60 ))"
   fi
+}
+
+# Helper: compute elapsed percentage of a rate-limit window from resets_at.
+# Echoes an integer 0-100, or "-1" if resets_at is unusable.
+elapsed_pct_from_reset() {
+  local window_secs="$1" resets_at="$2"
+  if [ -z "$resets_at" ] || [ "$resets_at" = "null" ]; then
+    echo "-1"
+    return
+  fi
+  local now elapsed_secs
+  now=$(date +%s)
+  elapsed_secs=$((window_secs - (resets_at - now)))
+  [ "$elapsed_secs" -lt 0 ] && elapsed_secs=0
+  [ "$elapsed_secs" -gt "$window_secs" ] && elapsed_secs="$window_secs"
+  echo "$((elapsed_secs * 100 / window_secs))"
 }
 
 # Helper: append reset countdown if usage >= show_reset_at threshold
@@ -166,6 +192,85 @@ make_short() {
   printf '\033[90m[\033[0m%b%s %s%%\033[0m\033[90m]\033[0m' "$color" "$label" "$pct_int"
 }
 
+# Helper: rate-limit bar with outside percentage, in-bar elapsed-time marker,
+# and trailing countdown. Format: "LABEL NN% [bar_with_marker] COUNTDOWN"
+make_meter_bar() {
+  local label="$1" pct_raw="$2" window_secs="$3" resets_at="$4"
+  local pct_int=$(printf '%.0f' "$pct_raw")
+  local filled
+  filled=$(echo "$pct_raw" | awk '{n=int($1/10+0.5); if(n>10) n=10; if(n<0) n=0; print n}')
+  local width=10
+
+  # Compute elapsed-time marker position (-1 when we can't)
+  local marker_pos=-1
+  local elapsed_pct
+  elapsed_pct=$(elapsed_pct_from_reset "$window_secs" "$resets_at")
+  if [ "$elapsed_pct" -ge 0 ]; then
+    marker_pos=$((elapsed_pct * width / 100))
+    [ "$marker_pos" -gt $((width - 1)) ] && marker_pos=$((width - 1))
+  fi
+
+  local fill_color
+  fill_color=$(echo "$pct_raw" | awk '{if($1>=80) print "\033[31m"; else if($1>=60) print "\033[33m"; else print "\033[32m"}')
+  local dim='\033[37m'
+  local marker_color='\033[1;91m'
+  local reset='\033[0m'
+
+  local bar="" i
+  for ((i=0; i<width; i++)); do
+    if [ "$i" -eq "$marker_pos" ]; then
+      bar="${bar}${marker_color}|${reset}"
+    elif [ "$i" -lt "$filled" ]; then
+      bar="${bar}${fill_color}█${reset}"
+    else
+      bar="${bar}${dim}░${reset}"
+    fi
+  done
+
+  printf "%s %2d%% [%b]" "$label" "$pct_int" "$bar"
+
+  # Countdown when usage >= show_reset_at (default 0 = always) and we have a reset time
+  if [ "$elapsed_pct" -ge 0 ]; then
+    local above
+    above=$(echo "$pct_raw $show_reset_at" | awk '{print ($1 >= $2) ? 1 : 0}')
+    if [ "$above" -eq 1 ]; then
+      local remaining=$(( resets_at - $(date +%s) ))
+      printf ' \033[90m%s\033[0m' "$(format_remaining "$remaining")"
+    fi
+  fi
+}
+
+# Helper: short rate-limit meter with in-bracket burn icon and trailing countdown.
+# Burn icon fires when usage is pulling ahead of the clock by more than
+# burn_threshold percentage points, gated by elapsed >= 20% to avoid noise at
+# window start.
+make_meter_short() {
+  local label="$1" pct_raw="$2" window_secs="$3" resets_at="$4"
+  local pct_int=$(printf '%.0f' "$pct_raw")
+  local color
+  color=$(echo "$pct_raw" | awk '{if($1>=80) print "\033[31m"; else if($1>=60) print "\033[33m"; else print "\033[32m"}')
+
+  local burn_icon=""
+  local elapsed_pct
+  elapsed_pct=$(elapsed_pct_from_reset "$window_secs" "$resets_at")
+  if [ "$elapsed_pct" -ge 0 ]; then
+    local burn
+    burn=$(echo "$pct_raw $elapsed_pct $burn_threshold" | awk '{print ($2 >= 20 && $1 > $2 + $3) ? 1 : 0}')
+    [ "$burn" -eq 1 ] && burn_icon='\033[1;91m↑\033[0m'
+  fi
+
+  printf '\033[90m[\033[0m%b%s %s%%\033[0m%b\033[90m]\033[0m' "$color" "$label" "$pct_int" "$burn_icon"
+
+  if [ "$elapsed_pct" -ge 0 ]; then
+    local above
+    above=$(echo "$pct_raw $show_reset_at" | awk '{print ($1 >= $2) ? 1 : 0}')
+    if [ "$above" -eq 1 ]; then
+      local remaining=$(( resets_at - $(date +%s) ))
+      printf ' \033[90m%s\033[0m' "$(format_remaining "$remaining")"
+    fi
+  fi
+}
+
 component_ctx_bar() {
   local pct
   pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
@@ -184,32 +289,32 @@ component_5h_bar() {
   local pct
   pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
   [ -z "$pct" ] && return
-  make_bar "5h" "$pct"
-  maybe_reset_suffix "$pct" "$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')"
+  make_meter_bar "5h" "$pct" "$WINDOW_5H_SECS" \
+    "$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')"
 }
 
 component_5h_short() {
   local pct
   pct=$(echo "$input" | jq -r '.rate_limits.five_hour.used_percentage // empty')
   [ -z "$pct" ] && return
-  make_short "5h" "$pct"
-  maybe_reset_suffix "$pct" "$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')"
+  make_meter_short "5h" "$pct" "$WINDOW_5H_SECS" \
+    "$(echo "$input" | jq -r '.rate_limits.five_hour.resets_at // empty')"
 }
 
 component_7d_bar() {
   local pct
   pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
   [ -z "$pct" ] && return
-  make_bar "7d" "$pct"
-  maybe_reset_suffix "$pct" "$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')"
+  make_meter_bar "7d" "$pct" "$WINDOW_7D_SECS" \
+    "$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')"
 }
 
 component_7d_short() {
   local pct
   pct=$(echo "$input" | jq -r '.rate_limits.seven_day.used_percentage // empty')
   [ -z "$pct" ] && return
-  make_short "7d" "$pct"
-  maybe_reset_suffix "$pct" "$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')"
+  make_meter_short "7d" "$pct" "$WINDOW_7D_SECS" \
+    "$(echo "$input" | jq -r '.rate_limits.seven_day.resets_at // empty')"
 }
 
 component_cost() {

--- a/plugins/redline/skills/config/SKILL.md
+++ b/plugins/redline/skills/config/SKILL.md
@@ -14,7 +14,8 @@ Interactive configuration for the redline statusline.
 ## Step 1: Show current config
 
 Read `~/.claude/statusline-config.json` if it exists. If not, note the defaults:
-- `show_reset_at`: 70
+- `show_reset_at`: 0
+- `burn_threshold`: 10
 - `lines`: `[["ps1","git","update"],["model","ctx_bar","5h_bar","7d_bar","cost","lines"]]`
 
 ## Step 2: Show the dashboard
@@ -28,10 +29,11 @@ Current layout:
 
 Preview:
   rmbug@veles:~/dev  main SM  ↑ claude code 2.2.0 available
-  Claude Opus 4.6  ctx [####8%....] 5h [###27%....] 3h12m  7d [#12%......] 5d4h  $0.42  +156 -23
+  Claude Opus 4.6  ctx [####8%....] 5h 27% [###|.......] 4h  7d 12% [#|........] 6d  $0.42  +156 -23
 
 Settings:
-  show_reset_at: 70  (show reset countdown when usage >= 70%)
+  show_reset_at: 0   (always show reset countdown)
+  burn_threshold: 10 (flag burn when usage > elapsed + 10%)
 ```
 
 Then list ALL available components grouped by category:
@@ -53,10 +55,14 @@ Model:
 Meters (bar = visual bar, short = compact text):
   ctx_bar      context window bar            ctx [####8%......]
   ctx_short    context window text           [ctx 8%]
-  5h_bar       5h rate limit bar             5h [###27%......] 3h12m
-  5h_short     5h rate limit text            [5h 27%] 3h12m
-  7d_bar       7d rate limit bar             7d [#12%........] 5d4h
-  7d_short     7d rate limit text            [7d 12%] 5d4h
+  5h_bar       5h rate limit bar             5h 27% [##|########] 4h
+  5h_short     5h rate limit text            [5h 27%↑] 4h
+  7d_bar       7d rate limit bar             7d 12% [#|.........] 6d
+  7d_short     7d rate limit text            [7d 12%] 6d
+
+Rate-limit bars include a `|` marker at the elapsed-time position — fill past
+the marker means usage is pulling ahead of the clock. Short variants get a
+bright red `↑` inside the brackets when burning hot (usage > elapsed + burn_threshold).
 
 Stats:
   cost         session cost                  $0.42
@@ -66,7 +72,9 @@ Updates:
   update       new version available          ↑ 2.2.0
 ```
 
-Note: reset countdowns (like `3h12m`) only appear when usage >= `show_reset_at`.
+Note: countdowns show the coarsest nonzero unit, rounded up (e.g. 4h30m → 5h,
+3d15h → 4d). They always appear by default; set `show_reset_at` to a threshold
+(0-100) to hide them at low usage.
 
 ## Step 3: Ask what to change
 
@@ -76,11 +84,11 @@ If the user already said what they want, apply it. Otherwise ask. Common operati
 - Add/remove components
 - Move components between lines
 - Add/remove lines
-- Change `show_reset_at`
+- Change `show_reset_at` or `burn_threshold`
 
 ## Step 4: Write config
 
-Write the updated config to `~/.claude/statusline-config.json`. Always include `show_reset_at` if it differs from the default 70.
+Write the updated config to `~/.claude/statusline-config.json`. Always include `show_reset_at` and `burn_threshold` if they differ from the defaults (0 and 10 respectively).
 
 ## Step 5: Confirm
 

--- a/plugins/redline/skills/setup/SKILL.md
+++ b/plugins/redline/skills/setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: init
+name: setup
 description: |
   Initial setup for the redline statusline plugin. Use when the user says
-  /redline:init, "set up redline", or "install redline statusline". Creates
+  /redline:setup, "set up redline", or "install redline statusline". Creates
   the wrapper script and statusLine setting. Run once after install.
 ---
 


### PR DESCRIPTION
## Summary

Two changes in one PR, both touching the redline plugin:

1. **Rate-limit bars gain a visual elapsed-time marker** so you can tell at a glance whether your usage is pacing with real time.
2. **Rename `/redline:init` → `/redline:setup`** (closes #14) to avoid collision with Claude Code's native `/init` command.

---

### Bar variants (`5h_bar`, `7d_bar`)

New format: `LABEL NN% [bar|with|marker] COUNTDOWN`

```
 5h  5% [█|░░░░░░░░] 5h     fresh session
 5h 30% [███|░░░░░░] 4h     perfect pacing
 5h 50% [███|█░░░░░] 4h     slight burn (usage past marker)
 5h 80% [██|█████░░] 4h     burning hot
 5h 20% [██░░░░|░░░] 2h     cruising (marker past usage)
 5h 90% [█████████|] 15m    near reset
```

- `|` sits at `elapsed_pct * 10 / 100`, clamped to `[0, 9]`
- Fill past the marker = burning faster than real time
- Fill behind the marker = slack, plenty of headroom

### Short variants (`5h_short`, `7d_short`)

Burn icon `↑` inside brackets when usage pulls ahead of the clock:

```
[5h 30%] 4h       perfect pacing — no icon
[5h 50%↑] 4h      burning (50% used, 30% elapsed, gap > threshold)
[5h 80%↑] 4h      burning hot
[5h 20%] 2h       cruising — no icon
```

Gated by `elapsed >= 20%` to avoid false alarms right after a window resets.

### Countdown format

Rewritten to show the coarsest nonzero unit, rounded up:

- `4h30m` → `5h`
- `4h15m` → `5h`
- `4h` (exact) → `4h`
- `3d15h` → `4d`
- `45s` → `1m`

### Config changes

- `show_reset_at` default: `70` → `0` (always show countdown)
- New `burn_threshold` setting, default `10` (percentage-point gap)
- `ctx_bar` / `ctx_short` unchanged — context has no reset window

### Rename `/redline:init` → `/redline:setup`

The native Claude Code `/init` command initializes a `CLAUDE.md` file. Our `/redline:init` shadowed that in muscle memory and skill search. Renaming to `/redline:setup` clarifies intent and removes the collision. README updated.

### Implementation notes

Window durations (`WINDOW_5H_SECS=18000`, `WINDOW_7D_SECS=604800`) are hardcoded. The statusline JSON payload only exposes `used_percentage` and `resets_at` per window ([docs](https://code.claude.com/docs/en/statusline)), so the window size itself can't be read dynamically. Commented in the source; if Anthropic changes tier durations, the marker goes stale silently.

Bumped to 1.2.0.

Closes #14

## Test plan

- [x] All scenarios render correctly (verified with mock stdin)
- [x] Missing `resets_at` gracefully degrades (bar without marker, no countdown)
- [x] Countdown rounding: 4h30m → 5h, 4h exact → 4h, 3d15h → 4d
- [x] Short burn icon fires when `elapsed >= 20 && usage > elapsed + 10`
- [x] Short burn icon does NOT fire at window start (elapsed < 20)
- [ ] `/redline:setup` triggers on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)