### PR TITLE
feat(git-pr-whip): new plugin — PostToolUse reminders after git commit (v1.0.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,6 +30,11 @@
       "name": "clockwork",
       "source": "./plugins/clockwork",
       "description": "Periodic time injection so Claude knows what day and time it is"
+    },
+    {
+      "name": "git-pr-whip",
+      "source": "./plugins/git-pr-whip",
+      "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commits — check for closed PRs, post review-feedback recap comments"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Plugins include hooks that run automatically — they need `/plugin install`.
 | [git-governor](plugins/git-governor/) | Git governance via PreToolUse hooks — block or prompt on amends, force pushes, protected branches | `/plugin install git-governor@allixsenos` |
 | [redline](plugins/redline/) | Configurable statusline with progress bars, git info, cost tracking | `/plugin install redline@allixsenos` |
 | [clockwork](plugins/clockwork/) | Periodic time injection so Claude knows what day and time it is | `/plugin install clockwork@allixsenos` |
+| [git-pr-whip](plugins/git-pr-whip/) | PostToolUse reminders after `git commit` — check if the PR was closed, post review-feedback recaps | `/plugin install git-pr-whip@allixsenos` |
 
 ## Skills
 

--- a/plugins/git-pr-whip/.claude-plugin/plugin.json
+++ b/plugins/git-pr-whip/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "git-pr-whip",
+  "version": "1.0.0",
+  "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commits — check for closed PRs, post review-feedback recap comments",
+  "author": {
+    "name": "Luka Kladaric",
+    "url": "https://github.com/allixsenos"
+  },
+  "license": "MIT"
+}

--- a/plugins/git-pr-whip/LICENSE
+++ b/plugins/git-pr-whip/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 allixsenos
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/git-pr-whip/README.md
+++ b/plugins/git-pr-whip/README.md
@@ -1,0 +1,39 @@
+# git-pr-whip
+
+Keeps Claude honest about PR hygiene after it commits.
+
+Claude is great at forgetting two specific things after a `git commit`:
+
+1. **The PR it's updating might already be closed.** If you squash-merged the PR while Claude was doing other work, Claude will happily keep pushing to that stale branch and watch the push get rejected — or worse, re-open a dead PR. The branch should be rebuilt from the current default branch.
+2. **Review feedback it addressed in the commit never gets acknowledged on the PR itself.** Reviewers left suggestions; Claude accepted some, dismissed others, silently. The PR conversation has no record of what changed and why.
+
+This plugin nudges it, quietly.
+
+## What it does
+
+A `PostToolUse` hook fires after every Bash command. When the command is a `git commit` (any variant: `-m`, `--amend`, `--fixup`, etc.), it injects an `additionalContext` reminder that Claude sees but you don't:
+
+> **PR hygiene reminder (git-pr-whip plugin):**
+>
+> 1. If this commit is meant to update an existing PR, before pushing run `gh pr view --json state,url` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one.
+> 2. If this commit addresses PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff.
+
+Non-commit Bash calls are silent. The hook also ignores `git commit` inside quoted strings or heredoc bodies, so writing a shell script that happens to mention the string doesn't trigger it.
+
+## Install
+
+```
+/plugin marketplace add allixsenos/claude-plugins
+/plugin install git-pr-whip@allixsenos
+/reload-plugins
+```
+
+No configuration.
+
+## Why a hook and not memory or CLAUDE.md
+
+Because Claude forgets. Memory and CLAUDE.md get compacted, glossed over, or outweighed by whatever is currently on-screen. A PostToolUse injection happens at the exact moment the reminder is actionable — immediately after `git commit`, before the next `git push` or PR edit — which makes it much harder to skip.
+
+## Pairs well with
+
+- **git-governor** — catches the dangerous stuff (amends on pushed commits, force pushes, commits to `main`). `git-pr-whip` covers the workflow-hygiene stuff governor doesn't block.

--- a/plugins/git-pr-whip/hooks/git-pr-whip.sh
+++ b/plugins/git-pr-whip/hooks/git-pr-whip.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# git-pr-whip — PostToolUse hook that injects PR hygiene reminders after git commits.
+#
+# Fires after any `git commit` (including --amend). Emits `additionalContext` JSON
+# on stdout so Claude Code feeds the reminder into the model's context (invisible
+# to the user). Silent on any non-commit Bash call.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+# Only Bash commands are in scope
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+[[ -n "$COMMAND" ]] || exit 0
+
+# --- Sanitize command to detect `git commit` without false positives ---
+# Same approach as git-governor: strip heredocs, quoted strings, unwrap
+# subshells, and normalize git global flags so patterns match reliably.
+
+SCAN="$COMMAND"
+
+# Collapse line continuations so "git commit \<nl>-m ..." matches
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\\\n\s*/ /g' 2>/dev/null || printf '%s' "$COMMAND")
+
+# Strip heredoc bodies so a commit message that mentions "git commit" doesn't trigger
+if printf '%s' "$SCAN" | grep -q '<<'; then
+  STRIPPED=$(printf '%s' "$SCAN" | perl -0777 -pe "s/<<~?'?(\w+)'?\s*\n.*?\n\1\b//gs" 2>/dev/null) && SCAN="$STRIPPED"
+fi
+
+# Strip quoted strings (commit message bodies, etc.)
+SCAN=$(printf '%s' "$SCAN" | sed "s/'[^']*'//g" | sed 's/"[^"]*"//g')
+
+# Unwrap $(...) and `...` so "$(echo git) commit" still matches
+SCAN=$(printf '%s' "$SCAN" | sed 's/\$(\([^)]*\))/\1/g' | sed 's/`\([^`]*\)`/\1/g')
+
+# Normalize git global flags: "git -C /path commit" -> "git commit"
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\bgit\s+(?:(?:-[Cc]|--git-dir|--work-tree)(?:=\S+|\s+\S+)\s+)*/git /g')
+
+# Detect any git commit invocation (plain, --amend, -m, --fixup, etc.)
+if ! printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b'; then
+  exit 0
+fi
+
+# --- Emit additionalContext for Claude ---
+
+REMINDER="PR hygiene reminder (git-pr-whip plugin):
+1. If this commit is meant to update an existing PR, before pushing run \`gh pr view --json state,url\` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one.
+2. If this commit addresses PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff."
+
+jq -n --arg ctx "$REMINDER" '{
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $ctx
+  }
+}'
+
+exit 0

--- a/plugins/git-pr-whip/hooks/hooks.json
+++ b/plugins/git-pr-whip/hooks/hooks.json
@@ -1,0 +1,18 @@
+{
+  "description": "Inject PR hygiene reminders after git commits",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/git-pr-whip.sh",
+            "timeout": 3,
+            "description": "Git PR whip reminders"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- New **git-pr-whip** plugin. A `PostToolUse` hook fires after every Bash call; when the command is a `git commit` (any variant — `-m`, `--amend`, `--fixup`, `git -C ... commit`, subshell-wrapped), it emits `hookSpecificOutput.additionalContext` so Claude gets a short reminder invisible to the user.
- Two reminders injected, both aimed at known Claude blind spots after a commit:
  1. If the PR for this branch was closed/merged, the branch is stale — pull the default branch, create a new branch, open a fresh PR instead of pushing.
  2. If the commit addresses review feedback, post one recap comment on the PR summarizing what was accepted vs. dismissed with one-line reasons.
- Detection reuses the sanitization pattern from `git-governor` (heredocs, quoted strings, subshells, git global flags) so a commit message or a shell script that mentions the literal string `git commit` doesn't false-trigger.
- Wired into `.claude-plugin/marketplace.json` and the top-level plugins table in `README.md`.

## Test plan
- [x] JSON validates (`jq .` on marketplace + plugin + hooks manifests)
- [x] `bash -n` on the hook script
- [x] Fires on `git commit -m ...`, `git commit --amend`, and `git -C /tmp commit -m ...` (all emit `PostToolUse` with `ctx_len=602`)
- [x] Silent on `git status`, `Write` tool, `echo "git commit in string"`, and `cat <<EOF\ngit commit text\nEOF`
- [ ] `/plugin install git-pr-whip@allixsenos` from a local marketplace checkout and verify the reminder reaches Claude end-to-end