### PR TITLE
feat(git-pr-whip): git push trigger + block commit+push chains (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "git-pr-whip",
       "source": "./plugins/git-pr-whip",
-      "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments"
+      "description": "PR hygiene for Claude Code — subtle post-commit/push reminders (closed PR, scope expansion, review-feedback recap) plus a PreToolUse block on chained commit+push so the reminder can actually influence the push"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "git-pr-whip",
       "source": "./plugins/git-pr-whip",
-      "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commits — check for closed PRs, post review-feedback recap comments"
+      "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments"
     }
   ]
 }

--- a/plugins/git-pr-whip/.claude-plugin/plugin.json
+++ b/plugins/git-pr-whip/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-pr-whip",
-  "version": "1.0.0",
-  "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commits — check for closed PRs, post review-feedback recap comments",
+  "version": "1.1.0",
+  "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments",
   "author": {
     "name": "Luka Kladaric",
     "url": "https://github.com/allixsenos"

--- a/plugins/git-pr-whip/.claude-plugin/plugin.json
+++ b/plugins/git-pr-whip/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-pr-whip",
-  "version": "1.1.0",
-  "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments",
+  "version": "1.2.0",
+  "description": "PR hygiene for Claude Code — subtle post-commit/push reminders (closed PR, scope expansion, review-feedback recap) plus a PreToolUse block on chained commit+push so the reminder can actually influence the push",
   "author": {
     "name": "Luka Kladaric",
     "url": "https://github.com/allixsenos"

--- a/plugins/git-pr-whip/README.md
+++ b/plugins/git-pr-whip/README.md
@@ -8,11 +8,13 @@ Claude is great at forgetting three specific things around commit and push time:
 2. **The PR's scope has grown past its title and description.** Claude adds a "while I'm here" fix, then another, and the PR still says what the first commit was about. Reviewers lose trust when they open a PR titled *"fix null session"* and find a logger refactor. (Checked after `git push`.)
 3. **Review feedback Claude addressed never gets acknowledged on the PR itself.** Reviewers left suggestions; Claude accepted some, dismissed others, silently. The PR conversation has no record of what changed and why. (Checked after `git push`.)
 
-This plugin nudges it, quietly.
+It also forgets a fourth thing — that the above reminders can't help when commit and push are chained in one Bash call. So this plugin also **blocks** `git commit && git push` (and friends) before the tool runs, forcing the work into two turns so the reminder has a chance to land. More on that below.
+
+This plugin nudges it, quietly — and occasionally refuses to let Claude skip the nudge.
 
 ## What it prevents
 
-Three failure modes, reconstructed from real sessions (names changed, pacing tightened).
+Four failure modes, reconstructed from real sessions (names changed, pacing tightened). The first three are nudged; the fourth is outright denied.
 
 ### 1. Pushing into a PR that was already merged — nudged after `git commit`
 
@@ -82,6 +84,42 @@ With git-pr-whip, the post-push nudge triggers a single recap comment on the PR:
 > - ✗ #4 split `AuthResolver` into two classes → dismissed; the two halves share six private fields, splitting duplicates them with no win
 > - ✗ #5 tighten the email regex to `^[a-z0-9]` → dismissed; that rejects addresses with `+` aliases which we accept in prod (see #137)
 
+### 4. Chaining commit and push so the reminder can't land — blocked before the tool runs
+
+The reminders above fire *after* the tool call. That's fine when commit and push are two separate calls, but Claude often tries:
+
+```
+> commit the fix and push it
+
+● Bash(git commit -m "fix: null session" && git push)
+```
+
+With both commands in one shell invocation, the commit's post-commit reminder (*"is the PR still open? pull master first?"*) gets generated — but the push already ran. The reminder lands as context for Claude's *next* turn, which is now after the push, when it can't influence anything.
+
+git-pr-whip denies this pattern at `PreToolUse`:
+
+```
+● Bash(git commit -m "fix: null session" && git push)
+  ✗ denied by git-pr-whip: chaining `git commit` with `git push` in a single
+    Bash call is blocked. The post-commit PR-hygiene reminder only lands in
+    context AFTER the tool call finishes — if you've already chained the
+    push, the reminder can't change the outcome. Run them as separate Bash
+    calls: commit first, read the reminder, then decide whether to push.
+
+● Right — splitting them.
+● Bash(git commit -m "fix: null session")
+  ✓ [fix-auth abc1234] fix: null session
+  [reminder arrives: run `gh pr view --json state,url` before pushing]
+
+● Bash(gh pr view --json state)
+  {"state":"OPEN"}
+
+● Bash(git push)
+  ✓ …
+```
+
+Detection covers `&&`, `;`, `||`, `|`, subshells like `(git commit ... && git push)`, line continuations, and `git -C /path commit`. Standalone commits and pushes pass through untouched, and `git stash push` is correctly *not* matched (the regex requires `commit`/`push` to be the first word after `git`).
+
 ## First real catch (five minutes after install)
 
 The three transcripts above are fake. This one is not. I wrote the faux reproduction section, committed it, and pushed — and the plugin caught me on its own README commit, because the user had squash-merged the plugin's own PR ([#19](https://github.com/allixsenos/claude-plugins/pull/19)) while I was still editing. The commit landed on a now-dead branch. Verbatim session:
@@ -129,7 +167,10 @@ Without the nudge after `git commit`, the orphaned commit would have silently st
 
 ## What it does
 
-A `PostToolUse` hook fires after every Bash command. When the command is `git commit` (any variant: `-m`, `--amend`, `--fixup`) or `git push`, it injects an `additionalContext` reminder that Claude sees but you don't.
+Two hooks on the `Bash` tool:
+
+- **`PreToolUse`** (`block-chain.sh`) — denies any command that contains *both* `git commit` and `git push`. No reminder would reach Claude in time to affect the push otherwise.
+- **`PostToolUse`** (`git-pr-whip.sh`) — when the command is `git commit` (any variant: `-m`, `--amend`, `--fixup`) or `git push`, injects an `additionalContext` reminder that Claude sees but you don't.
 
 **After `git commit`:**
 

--- a/plugins/git-pr-whip/README.md
+++ b/plugins/git-pr-whip/README.md
@@ -2,18 +2,19 @@
 
 Keeps Claude honest about PR hygiene after it commits.
 
-Claude is great at forgetting two specific things after a `git commit`:
+Claude is great at forgetting three specific things around commit and push time:
 
-1. **The PR it's updating might already be closed.** If you squash-merged the PR while Claude was doing other work, Claude will happily keep pushing to that stale branch and watch the push get rejected — or worse, re-open a dead PR. The branch should be rebuilt from the current default branch.
-2. **Review feedback it addressed in the commit never gets acknowledged on the PR itself.** Reviewers left suggestions; Claude accepted some, dismissed others, silently. The PR conversation has no record of what changed and why.
+1. **The PR it's updating might already be closed.** If you squash-merged the PR while Claude was doing other work, Claude will happily keep pushing to that stale branch and watch the push get rejected — or worse, re-open a dead PR. The branch should be rebuilt from the current default branch. (Checked after `git commit`.)
+2. **The PR's scope has grown past its title and description.** Claude adds a "while I'm here" fix, then another, and the PR still says what the first commit was about. Reviewers lose trust when they open a PR titled *"fix null session"* and find a logger refactor. (Checked after `git push`.)
+3. **Review feedback Claude addressed never gets acknowledged on the PR itself.** Reviewers left suggestions; Claude accepted some, dismissed others, silently. The PR conversation has no record of what changed and why. (Checked after `git push`.)
 
 This plugin nudges it, quietly.
 
 ## What it prevents
 
-Two failure modes, both reconstructed from real sessions (names changed, pacing tightened).
+Three failure modes, reconstructed from real sessions (names changed, pacing tightened).
 
-### 1. Pushing into a PR that was already merged
+### 1. Pushing into a PR that was already merged — nudged after `git commit`
 
 ```
 > apply the reviewer's fix on #204, then push
@@ -39,7 +40,32 @@ Two failure modes, both reconstructed from real sessions (names changed, pacing 
 
 Four wasted tool calls, a confused rebase attempt, and the commit is now orphaned on a dead branch. With git-pr-whip, the `gh pr view` check happens *before* the push, right after the commit.
 
-### 2. Silent dismissal of review suggestions
+### 2. Scope creep without updating the PR — nudged after `git push`
+
+```
+> the auth-resolver PR is ready to push, but the logger module also has a race
+  condition that's been bugging me. fix that too while you're in there.
+
+● Edit(src/auth-resolver.ts)
+● Edit(src/logger.ts)           — unrelated subsystem
+● Bash(git commit -am "fix: logger init race on hot reload")
+● Bash(git push)
+  ✓ To github.com:acme/app.git
+     abc1234..def5678  fix-auth-resolver -> fix-auth-resolver
+
+PR #204 title:  "fix: null session in auth resolver"
+PR #204 body:   "Fixes the null session bug reported in #198."
+PR #204 diff:   src/auth-resolver.ts (+12 -3)
+                src/logger.ts       (+18 -6)   ← not mentioned in title or body
+```
+
+Next morning, reviewer:
+
+> Why is there a logger change in a PR titled *"null session in auth resolver"*? I was going to skim-approve based on the title. Splitting into two PRs.
+
+With git-pr-whip, the push nudge prompts Claude to run `gh pr edit 204 --title "..." --body "..."` right after the push, so the PR metadata matches what it actually contains before anyone looks at it.
+
+### 3. Silent dismissal of review suggestions — nudged after `git push`
 
 A reviewer left five line comments. Claude accepts three, dismisses two (one because the suggested refactor would duplicate private state across both halves, one because the suggested regex rejects a valid production input). The follow-up commit lands. The PR auto-merges on approval. The reviewer, days later:
 
@@ -47,7 +73,7 @@ A reviewer left five line comments. Claude accepts three, dismisses two (one bec
 
 Claude has no memory of the session. The diff shows only what changed, not what was *considered and rejected*. Now someone has to re-read the review, re-read the diff, and reconstruct the reasoning — or re-open the discussion from scratch.
 
-With git-pr-whip, the post-commit nudge triggers a single recap comment on the PR:
+With git-pr-whip, the post-push nudge triggers a single recap comment on the PR:
 
 > **Review recap (fix-auth-resolver @ abc1234):**
 > - ✓ #1 missing null check on `session.user` → added in `session.ts:88`
@@ -58,7 +84,7 @@ With git-pr-whip, the post-commit nudge triggers a single recap comment on the P
 
 ## First real catch (five minutes after install)
 
-The two transcripts above are fake. This one is not. I wrote the faux reproduction section, committed it, and pushed — and the plugin caught me on its own README commit, because the user had squash-merged the plugin's own PR ([#19](https://github.com/allixsenos/claude-plugins/pull/19)) while I was still editing. The commit landed on a now-dead branch. Verbatim session:
+The three transcripts above are fake. This one is not. I wrote the faux reproduction section, committed it, and pushed — and the plugin caught me on its own README commit, because the user had squash-merged the plugin's own PR ([#19](https://github.com/allixsenos/claude-plugins/pull/19)) while I was still editing. The commit landed on a now-dead branch. Verbatim session:
 
 ```
 ❯ add a faux reproduction of the scenario that the plugin prevents to the plugin's README
@@ -103,14 +129,21 @@ Without the nudge after `git commit`, the orphaned commit would have silently st
 
 ## What it does
 
-A `PostToolUse` hook fires after every Bash command. When the command is a `git commit` (any variant: `-m`, `--amend`, `--fixup`, etc.), it injects an `additionalContext` reminder that Claude sees but you don't:
+A `PostToolUse` hook fires after every Bash command. When the command is `git commit` (any variant: `-m`, `--amend`, `--fixup`) or `git push`, it injects an `additionalContext` reminder that Claude sees but you don't.
+
+**After `git commit`:**
+
+> **PR hygiene reminder (git-pr-whip plugin):**
+> If this commit is meant to update an existing PR, before pushing run `gh pr view --json state,url` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one.
+
+**After `git push`:**
 
 > **PR hygiene reminder (git-pr-whip plugin):**
 >
-> 1. If this commit is meant to update an existing PR, before pushing run `gh pr view --json state,url` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one.
-> 2. If this commit addresses PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff.
+> 1. If this push updates an existing PR, check whether the commits now on the branch have expanded the PR's scope past what its title and body describe (e.g. additional fixes, new features, or refactors added after the PR opened). If so, run `gh pr edit <num> --title ... --body ...` so reviewers see the full scope, not just what the PR originally claimed.
+> 2. If this push includes commits that address PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff.
 
-Non-commit Bash calls are silent. The hook also ignores `git commit` inside quoted strings or heredoc bodies, so writing a shell script that happens to mention the string doesn't trigger it.
+Other Bash calls are silent. `git stash push` is correctly ignored (the regex requires `commit`/`push` to be the first word after `git`). The hook also strips quoted strings and heredoc bodies before scanning, so a shell script or commit message that happens to mention `git commit` or `git push` doesn't trigger it.
 
 ## Install
 

--- a/plugins/git-pr-whip/hooks/block-chain.sh
+++ b/plugins/git-pr-whip/hooks/block-chain.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# git-pr-whip — PreToolUse hook that blocks `git commit` and `git push` from
+# being chained in a single Bash call.
+#
+# Rationale: the PostToolUse reminder on `git commit` injects guidance (is the
+# PR still open? scope grown? review-feedback recap needed?) that can only
+# influence Claude's next decision if there IS a next decision. When Claude
+# writes `git commit && git push`, the push has already been committed to by
+# the shell by the time the PostToolUse hook fires — the reminder arrives
+# after the fact. Blocking the chain forces a second Bash call, at which
+# point the reminder is in context.
+#
+# Detection: if the sanitized command contains BOTH `git commit` and
+# `git push` (in any order, separated by anything), deny. Standalone commits
+# or pushes pass through.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+[[ -n "$COMMAND" ]] || exit 0
+
+# --- Sanitize (same approach as git-governor and git-pr-whip.sh) ---
+
+SCAN="$COMMAND"
+
+# Collapse line continuations
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\\\n\s*/ /g' 2>/dev/null || printf '%s' "$COMMAND")
+
+# Strip heredoc bodies so a commit message containing "git push" doesn't match
+if printf '%s' "$SCAN" | grep -q '<<'; then
+  STRIPPED=$(printf '%s' "$SCAN" | perl -0777 -pe "s/<<~?'?(\w+)'?\s*\n.*?\n\1\b//gs" 2>/dev/null) && SCAN="$STRIPPED"
+fi
+
+# Strip quoted strings (commit messages, echoed strings)
+SCAN=$(printf '%s' "$SCAN" | sed "s/'[^']*'//g" | sed 's/"[^"]*"//g')
+
+# Unwrap $(...) and `...`
+SCAN=$(printf '%s' "$SCAN" | sed 's/\$(\([^)]*\))/\1/g' | sed 's/`\([^`]*\)`/\1/g')
+
+# Normalize git global flags
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\bgit\s+(?:(?:-[Cc]|--git-dir|--work-tree)(?:=\S+|\s+\S+)\s+)*/git /g')
+
+# --- Dispatch: block only when BOTH commit and push appear in one call ---
+
+if printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b' \
+   && printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b'; then
+  REASON="git-pr-whip: chaining \`git commit\` with \`git push\` in a single Bash call is blocked. The post-commit PR-hygiene reminder (is the PR still open? has the scope drifted? etc.) only lands in context AFTER the tool call finishes — if you've already chained the push, the reminder can't change the outcome. Run them as separate Bash calls: commit first, read the reminder, then decide whether to push."
+  jq -n --arg reason "$REASON" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/plugins/git-pr-whip/hooks/git-pr-whip.sh
+++ b/plugins/git-pr-whip/hooks/git-pr-whip.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# git-pr-whip — PostToolUse hook that injects PR hygiene reminders after git commits.
+# git-pr-whip — PostToolUse hook that injects PR hygiene reminders after git operations.
 #
-# Fires after any `git commit` (including --amend). Emits `additionalContext` JSON
-# on stdout so Claude Code feeds the reminder into the model's context (invisible
-# to the user). Silent on any non-commit Bash call.
+# Fires after `git commit` (any variant: --amend, -m, --fixup) and after `git push`.
+# Each subcommand gets a different reminder. Emits `additionalContext` JSON on
+# stdout so Claude Code feeds the reminder into the model's context (invisible to
+# the user). Silent on any other Bash call.
 
 set -euo pipefail
 
@@ -39,16 +40,21 @@ SCAN=$(printf '%s' "$SCAN" | sed 's/\$(\([^)]*\))/\1/g' | sed 's/`\([^`]*\)`/\1/
 # Normalize git global flags: "git -C /path commit" -> "git commit"
 SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\bgit\s+(?:(?:-[Cc]|--git-dir|--work-tree)(?:=\S+|\s+\S+)\s+)*/git /g')
 
-# Detect any git commit invocation (plain, --amend, -m, --fixup, etc.)
-if ! printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b'; then
+# Dispatch on subcommand. `\bgit\s+commit\b` / `\bgit\s+push\b` both require
+# commit/push to be the first word after `git`, so `git stash push` etc. won't
+# false-match. Silent on any other git invocation.
+if printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b'; then
+  REMINDER="PR hygiene reminder (git-pr-whip plugin):
+If this commit is meant to update an existing PR, before pushing run \`gh pr view --json state,url\` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one."
+elif printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b'; then
+  REMINDER="PR hygiene reminder (git-pr-whip plugin):
+1. If this push updates an existing PR, check whether the commits now on the branch have expanded the PR's scope past what its title and body describe (e.g. additional fixes, new features, or refactors added after the PR opened). If so, run \`gh pr edit <num> --title ... --body ...\` so reviewers see the full scope, not just what the PR originally claimed.
+2. If this push includes commits that address PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff."
+else
   exit 0
 fi
 
 # --- Emit additionalContext for Claude ---
-
-REMINDER="PR hygiene reminder (git-pr-whip plugin):
-1. If this commit is meant to update an existing PR, before pushing run \`gh pr view --json state,url\` for that branch. If the PR state is MERGED or CLOSED, the branch is stale — pull the latest default branch, create a new branch from it, and open a fresh PR instead of pushing to the old one.
-2. If this commit addresses PR review feedback from other users or agents, post one recap comment on the PR summarizing which suggestions you accepted vs. dismissed, with a one-line reason for each dismissal — so reviewers don't have to reconstruct it from the diff."
 
 jq -n --arg ctx "$REMINDER" '{
   hookSpecificOutput: {

--- a/plugins/git-pr-whip/hooks/hooks.json
+++ b/plugins/git-pr-whip/hooks/hooks.json
@@ -1,6 +1,19 @@
 {
-  "description": "Inject PR hygiene reminders after git commits",
+  "description": "Inject PR hygiene reminders after git commits/pushes; block commit+push chaining so the commit reminder can influence the push",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-chain.sh",
+            "timeout": 3,
+            "description": "Block git commit && git push chains"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

Two related changes shipping together as **v1.2.0**:

### 1. Add `git push` trigger (PostToolUse)
The PostToolUse hook now fires on `git push` as well as `git commit`, and splits the reminders by subcommand:

- **On `git commit`** — closed-PR check only. Still catches the common *"you just committed onto a branch whose PR was squash-merged 20 minutes ago"* scenario before the push happens.
- **On `git push` (new)** — two nudges:
  1. **Scope expansion** — if the commits on the branch have grown past what the PR title/body describe (unrelated fixes, new features, large refactors), run `gh pr edit <num> --title ... --body ...` so reviewers see the full scope.
  2. **Review-feedback recap** (moved from commit) — post one recap comment summarizing which review suggestions were accepted vs. dismissed with a one-line reason for each dismissal. Push is the right moment: that's when the PR actually receives the updated commits and reviewers will look at it next.

### 2. Block `git commit && git push` chains (PreToolUse)

The PostToolUse reminder only lands in context *between* tool calls. When Claude writes `git commit && git push`, the shell runs both before the hook fires — the reminder arrives as context for the next turn, after the push, too late to influence the push decision.

New PreToolUse hook (`block-chain.sh`) denies any Bash command whose sanitized form contains BOTH `git commit` and `git push`. Claude is forced to split the workflow into two Bash calls, and the post-commit reminder gets one turn of Claude's attention before the push decision.

**Denied** (via `&&`, `;`, `||`, `|`, subshells, line continuations, `git -C /path` prefixes):
```
git commit -m "x" && git push
git commit; git push
git commit --amend && git push --force-with-lease
(git commit -m "x" && git push)
git push origin main && git commit -m x     # reverse order
git -C /tmp commit -m x && git push
```

**Allowed** (standalone, or push/commit mentioned only inside stripped context):
```
git commit -m "x"                                           # standalone
git push                                                    # standalone
git commit -m "deploy after git push"                       # push in quoted msg
echo "git commit && git push"                               # fully quoted
git add file && git commit -m x                             # no push
git push && gh pr edit 1                                    # no commit
git stash push -m wip && git commit -m x                    # stash push ≠ git push
```

Both hooks share the same sanitization pipeline (strips heredocs, quoted strings, subshells, normalizes git global flags). The detection regex requires `commit`/`push` to be the first word after `git`, so `git stash push` correctly doesn't false-match.

## Docs

- Bumped to **v1.2.0**
- Marketplace + `plugin.json` descriptions updated to cover both hooks
- README: intro now lists three failure modes each labeled by trigger (`git commit` vs `git push`), plus a fourth section on the chain block; *"What it prevents"* has four scenarios (three nudged + one denied with a mock denial transcript); *"What it does"* lists both hooks

## Test plan

- [x] PostToolUse fixture matrix (11 cases): commit fires `ctx_len=332`, push fires `ctx_len=683`, `git stash push` / `git pull` / `git status` / quoted / heredoc all silent
- [x] PreToolUse fixture matrix (19 cases): 9 chained variants deny, 10 non-chained cases silent
- [x] `bash -n` + `jq .` on all manifests
- [ ] `/reload-plugins` and exercise end-to-end — confirm v1.2.0 reminder text lands on commit/push and chained call is blocked

## Notes

- Originally opened as #22 (stacked PR). Consolidated here at the author's direction since this is all one coherent release.