### PR TITLE
feat(git-pr-whip): block commit+push chains at PreToolUse (v1.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
     {
       "name": "git-pr-whip",
       "source": "./plugins/git-pr-whip",
-      "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments"
+      "description": "PR hygiene for Claude Code — subtle post-commit/push reminders (closed PR, scope expansion, review-feedback recap) plus a PreToolUse block on chained commit+push so the reminder can actually influence the push"
     }
   ]
 }

--- a/plugins/git-pr-whip/.claude-plugin/plugin.json
+++ b/plugins/git-pr-whip/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-pr-whip",
-  "version": "1.1.0",
-  "description": "PostToolUse hook that injects subtle PR hygiene reminders after git commit and git push — check for closed PRs, flag scope expansion, post review-feedback recap comments",
+  "version": "1.2.0",
+  "description": "PR hygiene for Claude Code — subtle post-commit/push reminders (closed PR, scope expansion, review-feedback recap) plus a PreToolUse block on chained commit+push so the reminder can actually influence the push",
   "author": {
     "name": "Luka Kladaric",
     "url": "https://github.com/allixsenos"

--- a/plugins/git-pr-whip/README.md
+++ b/plugins/git-pr-whip/README.md
@@ -8,11 +8,13 @@ Claude is great at forgetting three specific things around commit and push time:
 2. **The PR's scope has grown past its title and description.** Claude adds a "while I'm here" fix, then another, and the PR still says what the first commit was about. Reviewers lose trust when they open a PR titled *"fix null session"* and find a logger refactor. (Checked after `git push`.)
 3. **Review feedback Claude addressed never gets acknowledged on the PR itself.** Reviewers left suggestions; Claude accepted some, dismissed others, silently. The PR conversation has no record of what changed and why. (Checked after `git push`.)
 
-This plugin nudges it, quietly.
+It also forgets a fourth thing — that the above reminders can't help when commit and push are chained in one Bash call. So this plugin also **blocks** `git commit && git push` (and friends) before the tool runs, forcing the work into two turns so the reminder has a chance to land. More on that below.
+
+This plugin nudges it, quietly — and occasionally refuses to let Claude skip the nudge.
 
 ## What it prevents
 
-Three failure modes, reconstructed from real sessions (names changed, pacing tightened).
+Four failure modes, reconstructed from real sessions (names changed, pacing tightened). The first three are nudged; the fourth is outright denied.
 
 ### 1. Pushing into a PR that was already merged — nudged after `git commit`
 
@@ -82,6 +84,42 @@ With git-pr-whip, the post-push nudge triggers a single recap comment on the PR:
 > - ✗ #4 split `AuthResolver` into two classes → dismissed; the two halves share six private fields, splitting duplicates them with no win
 > - ✗ #5 tighten the email regex to `^[a-z0-9]` → dismissed; that rejects addresses with `+` aliases which we accept in prod (see #137)
 
+### 4. Chaining commit and push so the reminder can't land — blocked before the tool runs
+
+The reminders above fire *after* the tool call. That's fine when commit and push are two separate calls, but Claude often tries:
+
+```
+> commit the fix and push it
+
+● Bash(git commit -m "fix: null session" && git push)
+```
+
+With both commands in one shell invocation, the commit's post-commit reminder (*"is the PR still open? pull master first?"*) gets generated — but the push already ran. The reminder lands as context for Claude's *next* turn, which is now after the push, when it can't influence anything.
+
+git-pr-whip denies this pattern at `PreToolUse`:
+
+```
+● Bash(git commit -m "fix: null session" && git push)
+  ✗ denied by git-pr-whip: chaining `git commit` with `git push` in a single
+    Bash call is blocked. The post-commit PR-hygiene reminder only lands in
+    context AFTER the tool call finishes — if you've already chained the
+    push, the reminder can't change the outcome. Run them as separate Bash
+    calls: commit first, read the reminder, then decide whether to push.
+
+● Right — splitting them.
+● Bash(git commit -m "fix: null session")
+  ✓ [fix-auth abc1234] fix: null session
+  [reminder arrives: run `gh pr view --json state,url` before pushing]
+
+● Bash(gh pr view --json state)
+  {"state":"OPEN"}
+
+● Bash(git push)
+  ✓ …
+```
+
+Detection covers `&&`, `;`, `||`, `|`, subshells like `(git commit ... && git push)`, line continuations, and `git -C /path commit`. Standalone commits and pushes pass through untouched, and `git stash push` is correctly *not* matched (the regex requires `commit`/`push` to be the first word after `git`).
+
 ## First real catch (five minutes after install)
 
 The three transcripts above are fake. This one is not. I wrote the faux reproduction section, committed it, and pushed — and the plugin caught me on its own README commit, because the user had squash-merged the plugin's own PR ([#19](https://github.com/allixsenos/claude-plugins/pull/19)) while I was still editing. The commit landed on a now-dead branch. Verbatim session:
@@ -129,7 +167,10 @@ Without the nudge after `git commit`, the orphaned commit would have silently st
 
 ## What it does
 
-A `PostToolUse` hook fires after every Bash command. When the command is `git commit` (any variant: `-m`, `--amend`, `--fixup`) or `git push`, it injects an `additionalContext` reminder that Claude sees but you don't.
+Two hooks on the `Bash` tool:
+
+- **`PreToolUse`** (`block-chain.sh`) — denies any command that contains *both* `git commit` and `git push`. No reminder would reach Claude in time to affect the push otherwise.
+- **`PostToolUse`** (`git-pr-whip.sh`) — when the command is `git commit` (any variant: `-m`, `--amend`, `--fixup`) or `git push`, injects an `additionalContext` reminder that Claude sees but you don't.
 
 **After `git commit`:**
 

--- a/plugins/git-pr-whip/hooks/block-chain.sh
+++ b/plugins/git-pr-whip/hooks/block-chain.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# git-pr-whip — PreToolUse hook that blocks `git commit` and `git push` from
+# being chained in a single Bash call.
+#
+# Rationale: the PostToolUse reminder on `git commit` injects guidance (is the
+# PR still open? scope grown? review-feedback recap needed?) that can only
+# influence Claude's next decision if there IS a next decision. When Claude
+# writes `git commit && git push`, the push has already been committed to by
+# the shell by the time the PostToolUse hook fires — the reminder arrives
+# after the fact. Blocking the chain forces a second Bash call, at which
+# point the reminder is in context.
+#
+# Detection: if the sanitized command contains BOTH `git commit` and
+# `git push` (in any order, separated by anything), deny. Standalone commits
+# or pushes pass through.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+[[ "$TOOL_NAME" == "Bash" ]] || exit 0
+[[ -n "$COMMAND" ]] || exit 0
+
+# --- Sanitize (same approach as git-governor and git-pr-whip.sh) ---
+
+SCAN="$COMMAND"
+
+# Collapse line continuations
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\\\n\s*/ /g' 2>/dev/null || printf '%s' "$COMMAND")
+
+# Strip heredoc bodies so a commit message containing "git push" doesn't match
+if printf '%s' "$SCAN" | grep -q '<<'; then
+  STRIPPED=$(printf '%s' "$SCAN" | perl -0777 -pe "s/<<~?'?(\w+)'?\s*\n.*?\n\1\b//gs" 2>/dev/null) && SCAN="$STRIPPED"
+fi
+
+# Strip quoted strings (commit messages, echoed strings)
+SCAN=$(printf '%s' "$SCAN" | sed "s/'[^']*'//g" | sed 's/"[^"]*"//g')
+
+# Unwrap $(...) and `...`
+SCAN=$(printf '%s' "$SCAN" | sed 's/\$(\([^)]*\))/\1/g' | sed 's/`\([^`]*\)`/\1/g')
+
+# Normalize git global flags
+SCAN=$(printf '%s' "$SCAN" | perl -pe 's/\bgit\s+(?:(?:-[Cc]|--git-dir|--work-tree)(?:=\S+|\s+\S+)\s+)*/git /g')
+
+# --- Dispatch: block only when BOTH commit and push appear in one call ---
+
+if printf '%s' "$SCAN" | grep -qE '\bgit\s+commit\b' \
+   && printf '%s' "$SCAN" | grep -qE '\bgit\s+push\b'; then
+  REASON="git-pr-whip: chaining \`git commit\` with \`git push\` in a single Bash call is blocked. The post-commit PR-hygiene reminder (is the PR still open? has the scope drifted? etc.) only lands in context AFTER the tool call finishes — if you've already chained the push, the reminder can't change the outcome. Run them as separate Bash calls: commit first, read the reminder, then decide whether to push."
+  jq -n --arg reason "$REASON" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/plugins/git-pr-whip/hooks/hooks.json
+++ b/plugins/git-pr-whip/hooks/hooks.json
@@ -1,6 +1,19 @@
 {
-  "description": "Inject PR hygiene reminders after git commits",
+  "description": "Inject PR hygiene reminders after git commits/pushes; block commit+push chaining so the commit reminder can influence the push",
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-chain.sh",
+            "timeout": 3,
+            "description": "Block git commit && git push chains"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
> Stacks on top of [#21](https://github.com/allixsenos/claude-plugins/pull/21). Base branch set to `git-pr-whip-push-trigger` so this diff stays small; retarget to `master` once #21 merges.

## Problem

The PostToolUse reminder on `git commit` only reaches Claude's context *between* tool calls. When Claude writes `git commit && git push`, the shell runs both before the hook fires — the reminder arrives as context for the next turn, after the push. It cannot influence the push decision.

## Fix

New PreToolUse hook (`block-chain.sh`) that denies any Bash command whose sanitized form contains BOTH `git commit` and `git push`. Claude is forced to split the workflow into two Bash calls; the post-commit reminder gets one turn of Claude's attention before the push decision.

Detection reuses the same sanitization pipeline as the PostToolUse hook (strips heredocs, quoted strings, subshells, normalizes git global flags).

## Covered

**Denied:**
- `git commit -m "x" && git push`
- `git commit; git push`
- `git commit || git push`
- `git add f && git commit -m x && git push`
- `git commit --amend && git push --force-with-lease`
- `(git commit -m x && git push)` (subshell)
- `git push origin main && git commit -m x` (reverse order)
- `git commit -m x \\<nl>&& git push` (line continuation)
- `git -C /tmp commit -m x && git push`

**Allowed:**
- Standalone `git commit` / `git push`
- `git commit -m "deploy after git push"` (mention in quoted message)
- `echo "git commit && git push"` (fully quoted)
- Heredoc body containing both
- `git add file && git commit -m x` (no push)
- `git push && gh pr edit 1` (no commit)
- `git stash push -m wip && git commit -m x` (stash push ≠ git push)

## Version / docs

- Bump to **v1.2.0**
- Marketplace and plugin.json descriptions updated
- README grows a fourth scenario in *"What it prevents"* showing the denied chain and the split-into-two-calls flow
- *"What it does"* section now lists both hooks (PreToolUse block + PostToolUse nudge)

## Test plan

- [x] 19-case fixture matrix: 9 chained variants deny, 10 non-chained cases silent — all as expected
- [x] `bash -n`, JSON validation on all manifests
- [ ] `/reload-plugins` after merge and confirm chained `git commit && git push` is blocked end-to-end