### PR TITLE
fix(redline): update check compares session version, not PATH claude (v1.3.0)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -79,6 +79,6 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 | `7d_short` | 7-day rate limit as `[7d NN%]` with `↑` inside when burning hot + countdown |
 | `cost` | Session cost in yellow (e.g. `$0.42`) |
 | `lines` | Lines added (green) and removed (red) |
-| `update` | Shows bold yellow `↑ X.Y.Z` when a newer Claude Code version is available. Checks npm at most once every 4 hours (cached in `/tmp/redline-claude-version`). Silent when up to date. |
+| `update` | Shows bold yellow `↑ claude code A.B.C → X.Y.Z` when the latest on npm is newer than the version running this session. The running version comes from `$CLAUDE_CODE_EXECPATH` — not `claude --version` on PATH — because Claude self-updates in the background, so a long-running session stays on its launch version until you restart it. Silent when current. npm checked at most once every 4 hours (cached in `/tmp/redline-claude-version`). |
 
 Components can be placed on any line in any order. Omit a component to disable it entirely — no work is done for components not in the config.

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -361,16 +361,25 @@ component_update() {
 
   [ -z "$latest" ] && return
 
-  # Get running version
-  local current
-  current=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  # Session version. Must come from CLAUDE_CODE_EXECPATH (the binary that
+  # launched THIS session), NOT `claude --version` on PATH. Claude self-updates
+  # in the background, so the PATH binary is usually newer than the running
+  # session — comparing against it silences the prompt exactly when the user
+  # most needs it (the session is stale and should be restarted to pick up
+  # whatever's on disk). Path format: .../versions/X.Y.Z
+  local current=""
+  if [ -n "$CLAUDE_CODE_EXECPATH" ]; then
+    current=$(basename "$CLAUDE_CODE_EXECPATH" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  fi
   [ -z "$current" ] && return
 
-  # Compare: if latest > current, show upgrade prompt
+  # If latest > current, show both so the user knows what a session restart
+  # would gain. Intentionally ignores whatever is on disk — the signal is
+  # "restart THIS session", not "run the installer".
   local newer
   newer=$(printf '%s\n%s\n' "$current" "$latest" | sort -V | tail -1)
   if [ "$newer" = "$latest" ] && [ "$latest" != "$current" ]; then
-    printf '\033[1;33m↑ claude code %s available\033[0m' "$latest"
+    printf '\033[1;33m↑ claude code %s → %s\033[0m' "$current" "$latest"
   fi
 }
 

--- a/plugins/redline/skills/config/SKILL.md
+++ b/plugins/redline/skills/config/SKILL.md
@@ -28,7 +28,7 @@ Current layout:
   Line 2: model, ctx_bar, 5h_bar, 7d_bar, cost, lines
 
 Preview:
-  rmbug@veles:~/dev  main SM  ↑ claude code 2.2.0 available
+  rmbug@veles:~/dev  main SM  ↑ claude code 2.1.117 → 2.1.118
   Claude Opus 4.6  ctx [####8%....] 5h 27% [###|.......] 4h  7d 12% [#|........] 6d  $0.42  +156 -23
 
 Settings:
@@ -69,7 +69,9 @@ Stats:
   lines        lines changed                 +156 -23
 
 Updates:
-  update       new version available          ↑ 2.2.0
+  update       session older than latest npm  ↑ 2.1.117 → 2.1.118
+               (compares $CLAUDE_CODE_EXECPATH vs. npm, not `claude` on PATH,
+                so it flags stale sessions even after a background self-update)
 ```
 
 Note: countdowns show the coarsest nonzero unit, rounded up (e.g. 4h30m → 5h,


### PR DESCRIPTION
## Problem

`component_update` was comparing `claude --version` (whatever the PATH-resolved binary reports — i.e. whatever's on disk) against the latest on npm. Claude self-updates in the background, so the PATH binary is usually already the latest — which silenced the prompt exactly when it was most useful: when a long-running session is still on its launch version and the user hasn't restarted yet. Stale sessions stayed stale, sometimes for a week+.

On my machine right now:
- Session binary: `2.1.117` (launched from `/Users/…/.local/share/claude/versions/2.1.117`)
- PATH `claude`: `2.1.118`
- Old logic: `latest=2.1.118`, `current=2.1.118` → silent, session looks up-to-date.
- Reality: the session is a version behind and won't pick up `2.1.118` until I restart it.

## Fix

Read the session's actual version from `$CLAUDE_CODE_EXECPATH`, which Claude Code sets to the path of the binary that launched *this* session (format `…/versions/X.Y.Z`). No fork needed — just `basename` + regex. Drop the `claude --version` path entirely: if `CLAUDE_CODE_EXECPATH` is missing or unparseable (non-Claude-Code host, custom launcher) the component returns empty rather than falling back to PATH, because that's exactly the false-negative the fix is addressing.

Also change the output format:

| Before | After |
|--------|-------|
| `↑ claude code 2.1.118 available` | `↑ claude code 2.1.117 → 2.1.118` |

The signal is now unambiguously *"restart THIS session to go from A to B"*, not *"go run the installer"*. Claude self-updates; the installer angle is already handled.

## Files

- `plugins/redline/scripts/statusline.sh` — `component_update` rewritten; version from `$CLAUDE_CODE_EXECPATH`, output shows `A → B`
- `plugins/redline/.claude-plugin/plugin.json` — v1.2.0 → **v1.3.0**
- `plugins/redline/README.md` — updated `update` component row
- `plugins/redline/skills/config/SKILL.md` — updated preview + components table
- `.claude-plugin/marketplace.json` — unchanged (existing description still fits)

## Test plan

5-case matrix ran on the branch — all as expected:

| Case | Expected | Result |
|------|----------|--------|
| This session (session 2.1.117, npm 2.1.118) | Shows `↑ claude code 2.1.117 → 2.1.118` | ✓ |
| `CLAUDE_CODE_EXECPATH` unset | Silent | ✓ |
| Session version == npm latest | Silent | ✓ |
| Session older than npm (`2.0.100` vs `2.1.118`) | Shows `↑ claude code 2.0.100 → 2.1.118` | ✓ |
| Session newer than npm (dev build `9.9.9`) | Silent | ✓ |

- [x] `bash -n` + `jq .` pass
- [ ] `/reload-plugins` post-merge, confirm the statusline shows `↑ claude code 2.1.117 → 2.1.118` end-to-end