### PR TITLE
fix(redline): read session version via $PPID walk, not $CLAUDE_CODE_EXECPATH (v1.3.1)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -79,6 +79,6 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 | `7d_short` | 7-day rate limit as `[7d NN%]` with `↑` inside when burning hot + countdown |
 | `cost` | Session cost in yellow (e.g. `$0.42`) |
 | `lines` | Lines added (green) and removed (red) |
-| `update` | Shows bold yellow `↑ claude code A.B.C → X.Y.Z` when the latest on npm is newer than the version running this session. The running version comes from `$CLAUDE_CODE_EXECPATH` — not `claude --version` on PATH — because Claude self-updates in the background, so a long-running session stays on its launch version until you restart it. Silent when current. npm checked at most once every 4 hours (cached in `/tmp/redline-claude-version`). |
+| `update` | Shows bold yellow `↑ claude code A.B.C → X.Y.Z` when the latest on npm is newer than the version running this session. Reads the running version from the statusline's parent process (the Claude Code binary that launched this session — path format `.../versions/X.Y.Z/claude`), not from `claude --version` on PATH. Claude self-updates in the background, so PATH always points at the latest on disk; a long-running session stays on its launch version until you restart it, and this component flags that specifically. Silent when current or when the session binary isn't at a versioned path (e.g. custom installs). npm checked at most once every 4 hours (cached in `/tmp/redline-claude-version`). |
 
 Components can be placed on any line in any order. Omit a component to disable it entirely — no work is done for components not in the config.

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -361,16 +361,29 @@ component_update() {
 
   [ -z "$latest" ] && return
 
-  # Session version. Must come from CLAUDE_CODE_EXECPATH (the binary that
-  # launched THIS session), NOT `claude --version` on PATH. Claude self-updates
-  # in the background, so the PATH binary is usually newer than the running
-  # session — comparing against it silences the prompt exactly when the user
-  # most needs it (the session is stale and should be restarted to pick up
-  # whatever's on disk). Path format: .../versions/X.Y.Z
-  local current=""
-  if [ -n "$CLAUDE_CODE_EXECPATH" ]; then
-    current=$(basename "$CLAUDE_CODE_EXECPATH" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-  fi
+  # Session version. Claude Code does NOT propagate $CLAUDE_CODE_EXECPATH to
+  # statusline subprocesses (see code.claude.com/docs/en/env-vars.md — only
+  # Bash tool gets the CC-internal env). So we walk up the process tree from
+  # $PPID and read each ancestor's executable path; Claude Code's self-update
+  # layout puts the binary at .../versions/X.Y.Z/claude, so the version falls
+  # out of the path. Linux uses /proc/<pid>/exe; macOS uses lsof.
+  #
+  # Why not just check `claude --version`? Because Claude self-updates in the
+  # background, so PATH almost always points at the newest binary, which
+  # silences the prompt exactly when the user most needs it (the running
+  # session is stale and should be restarted).
+  local current="" pid="$PPID" exe="" depth
+  for depth in 1 2 3 4 5; do
+    if [ -r "/proc/$pid/exe" ]; then
+      exe=$(readlink "/proc/$pid/exe" 2>/dev/null)
+    else
+      exe=$(lsof -a -p "$pid" -d txt 2>/dev/null | awk 'NR>1 {print $NF; exit}')
+    fi
+    current=$(printf '%s' "$exe" | grep -oE 'versions/[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d/ -f2)
+    [ -n "$current" ] && break
+    pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    { [ -z "$pid" ] || [ "$pid" = "0" ] || [ "$pid" = "1" ]; } && break
+  done
   [ -z "$current" ] && return
 
   # If latest > current, show both so the user knows what a session restart

--- a/plugins/redline/skills/config/SKILL.md
+++ b/plugins/redline/skills/config/SKILL.md
@@ -70,8 +70,9 @@ Stats:
 
 Updates:
   update       session older than latest npm  ↑ 2.1.117 → 2.1.118
-               (compares $CLAUDE_CODE_EXECPATH vs. npm, not `claude` on PATH,
-                so it flags stale sessions even after a background self-update)
+               (reads the session's running version from the statusline's
+                parent process, not `claude` on PATH, so it flags stale
+                sessions even after a background self-update)
 ```
 
 Note: countdowns show the coarsest nonzero unit, rounded up (e.g. 4h30m → 5h,


### PR DESCRIPTION
## The v1.3.0 bug

[#24](https://github.com/allixsenos/claude-plugins/pull/24) read `$CLAUDE_CODE_EXECPATH` to identify the session's running version. I tested it by running the wrapper from a Bash tool invocation and saw the correct output — so I shipped.

Claude Code *explicitly* strips its internal env vars from statusline subprocesses. Per [env-vars.md](https://code.claude.com/docs/en/env-vars.md):

> `CLAUDECODE`: Set to `1` in shell environments Claude Code spawns (Bash tool, tmux sessions). **Not set in hooks or status line commands.**

`$CLAUDE_CODE_EXECPATH` is in the same class. So v1.3.0 silently skipped the update check on every real statusline render. My test-from-the-Bash-tool inherited the env; the actual statusline spawn didn't. Classic false-positive testing path.

Reproduced with `env -i HOME=… PATH=… bash redline-wrapper.sh` (mimics CC's scrubbed-env spawn): v1.3.0 produces no update indicator. v1.3.1 produces `↑ claude code 2.1.117 → 2.1.118` as intended.

## The fix

Walk up the process tree from `$PPID` and read each ancestor's executable path. Claude Code's self-update layout puts the binary at `.../versions/X.Y.Z/claude`, so the version falls out of the path.

- **Linux**: `readlink /proc/<pid>/exe`
- **macOS**: `lsof -a -p <pid> -d txt | awk 'NR>1 {print $NF; exit}'`

Loop capped at 5 levels — walks ancestors in case a custom wrapper inserts shells between CC and the statusline. Falls through silently if no ancestor path matches `versions/X.Y.Z` (custom installs / npm-global / homebrew — those distributions don't self-update silently, so the staleness concern this check addresses isn't really a thing there).

## Files

- `plugins/redline/scripts/statusline.sh` — `component_update` rewritten to walk `$PPID`
- `plugins/redline/.claude-plugin/plugin.json` — 1.3.0 → **1.3.1**
- `plugins/redline/README.md` + `plugins/redline/skills/config/SKILL.md` — dropped `$CLAUDE_CODE_EXECPATH` mention, replaced with "parent process"

## Performance

`lsof` adds ~46ms per render on macOS; total wrapper runtime on my machine ~330ms. Not cached yet (can add a per-PID `/tmp` cache later if it becomes noticeable).

## Test plan

- [x] `env -i`-scrubbed wrapper invocation (simulates CC's spawn): shows `↑ claude code 2.1.117 → 2.1.118` as intended — the exact case v1.3.0 failed on
- [x] Same invocation on an up-to-date fixture (session == npm latest): silent
- [x] `$PPID` pointing to a non-versioned binary: silent (graceful fallback)
- [x] Staged v1.3.1 into the local plugin cache to verify against the live wrapper selection logic; the wrapper's highest-version picker now resolves to `.../cache/allixsenos/redline/1.3.1/scripts/statusline.sh`
- [ ] `/plugin update` or `/reload-plugins` after merge, confirm the live statusline inside Claude Code shows the indicator