### PR TITLE
feat(redline): mark unreachable ctx cells with ✘ when AUTO_COMPACT_WINDOW caps the window (v1.4.0)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -71,7 +71,7 @@ Override config path with the `CLAUDE_STATUSLINE_CONFIG` env var.
 | `cwd` | Bold blue working directory |
 | `git` | Yellow branch name + red status flags |
 | `model` | Cyan model display name |
-| `ctx_bar` | Context window usage as a 10-step progress bar |
+| `ctx_bar` | Context window usage as `ctx NN% [bar]` 10-step progress bar. When `CLAUDE_CODE_AUTO_COMPACT_WINDOW` is set below the model's full window, cells past the cap render as `✘` so unreachable capacity is visible at a glance. |
 | `ctx_short` | Context window usage as colored text in brackets |
 | `5h_bar` | 5-hour rate limit: `5h NN% [bar\|with\|marker] countdown`. `\|` shows elapsed-time position |
 | `5h_short` | 5-hour rate limit as `[5h NN%]` with `↑` inside when burning hot + countdown |

--- a/plugins/redline/scripts/statusline.sh
+++ b/plugins/redline/scripts/statusline.sh
@@ -26,63 +26,38 @@ burn_threshold=$(echo "$config" | jq -r '.burn_threshold // 10')
 WINDOW_5H_SECS=18000
 WINDOW_7D_SECS=604800
 
-# Helper: render a 10-step progress bar with percentage inside
+# Helper: render a 10-step progress bar with percentage outside.
+# Optional 3rd arg `cap_cells` (0..width) marks the rightmost cells as unusable
+# (rendered with ✘) — used by ctx_bar to show the auto-compact ceiling.
 make_bar() {
   local label="$1"
   local pct_raw="$2"
+  local cap_cells="${3:-10}"
   local pct_int=$(printf '%.0f' "$pct_raw")
   local filled=$(echo "$pct_raw" | awk '{n=int($1/10+0.5); if(n>10) n=10; if(n<0) n=0; print n}')
-  local text="${pct_int}%"
-  local text_len=${#text}
   local width=10
-  local text_start
-
-  if [ "$filled" -eq 0 ]; then
-    text_start=0
-  else
-    text_start=$((filled + 1))
-  fi
-
-  if [ $((text_start + text_len)) -gt "$width" ]; then
-    text_start=$((filled - text_len - 1))
-    [ "$text_start" -lt 0 ] && text_start=0
-  fi
-
-  local text_end=$((text_start + text_len))
   local fill_color
   fill_color=$(echo "$pct_raw" | awk '{if($1>=80) print "\033[31m"; else if($1>=60) print "\033[33m"; else print "\033[32m"}')
   local dim='\033[37m'
   local reset='\033[0m'
 
-  local bar=""
-  local i
+  local bar="" i ch
   for ((i=0; i<width; i++)); do
-    local ch
-    if [ "$i" -ge "$text_start" ] && [ "$i" -lt "$text_end" ]; then
-      ch="${text:$((i - text_start)):1}"
+    if [ "$i" -ge "$cap_cells" ]; then
+      ch="✘"
     elif [ "$i" -lt "$filled" ]; then
       ch="█"
     else
       ch="░"
     fi
-    local is_text=0
-    [ "$i" -ge "$text_start" ] && [ "$i" -lt "$text_end" ] && is_text=1
     if [ "$i" -lt "$filled" ]; then
-      if [ "$is_text" -eq 1 ]; then
-        bar="${bar}\033[48;5;236;37m${ch}${reset}"
-      else
-        bar="${bar}${fill_color}${ch}${reset}"
-      fi
+      bar="${bar}${fill_color}${ch}${reset}"
     else
-      if [ "$is_text" -eq 1 ]; then
-        bar="${bar}\033[48;5;236;37m${ch}${reset}"
-      else
-        bar="${bar}${dim}${ch}${reset}"
-      fi
+      bar="${bar}${dim}${ch}${reset}"
     fi
   done
 
-  printf "%s [%b]" "$label" "$bar"
+  printf "%s %2d%% [%b]" "$label" "$pct_int" "$bar"
 }
 
 # --- Component functions (only called if in config) ---
@@ -275,7 +250,17 @@ component_ctx_bar() {
   local pct
   pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
   [ -z "$pct" ] && return
-  make_bar "ctx" "$pct"
+  # If the user has capped auto-compact below the model's full window via
+  # CLAUDE_CODE_AUTO_COMPACT_WINDOW, mark the unreachable cells with ✘.
+  # The JSON's used_percentage is always reported against the model's full
+  # window (not the cap), so we have to compute the cap geometry ourselves.
+  local full cap cap_cells=10
+  full=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+  cap="$CLAUDE_CODE_AUTO_COMPACT_WINDOW"
+  if [[ "$cap" =~ ^[0-9]+$ ]] && [[ "$full" =~ ^[0-9]+$ ]] && [ "$cap" -gt 0 ] && [ "$cap" -lt "$full" ]; then
+    cap_cells=$((cap * 10 / full))
+  fi
+  make_bar "ctx" "$pct" "$cap_cells"
 }
 
 component_ctx_short() {


### PR DESCRIPTION
## Summary

- ctx_bar now reads `CLAUDE_CODE_AUTO_COMPACT_WINDOW` and marks unreachable cells with `✘` so the auto-compact ceiling is visible.
- Percentage label moves outside the bar (`ctx NN% [bar]`) to match the existing 5h/7d rate-limit bars — the bar now carries three glyphs (`█`, `░`, `✘`), so overlaying text on top of it was getting noisy.
- Bumps redline to v1.4.0; updates README entry for `ctx_bar`.

## Why

The statusline JSON's `used_percentage` is always reported against the model's full context window, even when the user has set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to cap auto-compaction below that. The docs explicitly call this out:

> Setting this variable decouples the compaction threshold from the status line's `used_percentage`, which always uses the model's full context window.

So the ctx bar would happily fill up to 80% on a 1M model while auto-compact had already triggered at, say, 50% — silent and confusing. The cap is real, the bar should show it.

## Implementation notes

- The envvar is read directly from the statusline subprocess env. Claude Code propagates user-set envvars to statusline children (only its own internal CC envvars like `CLAUDE_CODE_EXECPATH` are scrubbed), so no JSON wiring is needed.
- Cap geometry: `cap_cells = cap * 10 / full` (integer truncation, conservative — a cap of 55% on 1M renders as 5 usable cells). Guarded by regex on both values, so non-numeric envvar contents (`500k`, garbage) silently fall back to "no cap."
- Filled cells that have spilled past the cap render as `✘` in the fill color (red/yellow/green), so the "you're past the line" signal is preserved when usage exceeds the cap.

## Visual

```
no cap set:     ctx 20% [██░░░░░░░░]
cap=500k on 1M: ctx 20% [██░░░✘✘✘✘✘]
spilled past:   ctx 60% [█████✘✘✘✘✘]   (cells 5–9 in fill color)
```

## Cosmetic change for users without the cap envvar

The `%` label position changes from inside the bar to outside. Bar geometry is otherwise unchanged. Worth eyeballing if you're tight on statusline real estate.

## Test plan

- [x] No envvar set: bar renders as `ctx NN% [bar]` with `█`/`░` only, no `✘`.
- [x] `CLAUDE_CODE_AUTO_COMPACT_WINDOW=500000` on 1M model: cells 5–9 render as `✘`.
- [x] Non-numeric envvar (`500k`): regex guard rejects, falls back to no cap, no shell error noise.
- [x] Cap >= full: treated as no cap.
- [ ] Visual sanity check that `✘` aligns to one cell width in your terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)