### PR TITLE
fix(redline): changelog reads session version, rename config→configure (v1.4.1)

### DIFF
--- a/plugins/redline/.claude-plugin/plugin.json
+++ b/plugins/redline/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "redline",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Configurable statusline with progress bars, git info, cost tracking, and PS1-style prompt",
   "author": {
     "name": "Luka Kladarić",

--- a/plugins/redline/README.md
+++ b/plugins/redline/README.md
@@ -16,7 +16,7 @@ The setup skill creates a version-resilient wrapper and configures your statusLi
 ## Skills
 
 - `/redline:setup` — one-time setup after install
-- `/redline:config` — interactively change the layout
+- `/redline:configure` — interactively change the layout
 - `/redline:changelog` — show recent Claude Code release notes
 
 ## Features
@@ -38,7 +38,7 @@ The setup skill creates a version-resilient wrapper and configures your statusLi
 
 ## Configuration
 
-Create `~/.claude/statusline-config.json` or use `/redline:config`:
+Create `~/.claude/statusline-config.json` or use `/redline:configure`:
 
 ```json
 {

--- a/plugins/redline/skills/changelog/SKILL.md
+++ b/plugins/redline/skills/changelog/SKILL.md
@@ -9,25 +9,55 @@ description: |
 
 ## Steps
 
-1. Run these two commands in parallel:
-   - Get installed version: `claude --version`
-   - Get latest version: `npm view @anthropic-ai/claude-code version`
+1. Detect the running session's Claude Code version, NOT the version on PATH.
+   `claude --version` is unreliable here because Claude Code self-updates in the
+   background — PATH almost always points at the latest release on disk, even
+   when this session is still running an older binary. The whole point of this
+   command is "what release notes apply to me right now," so we have to read
+   the version from the actual session process.
 
-2. Fetch recent releases from GitHub:
+   Walk up the parent process tree from this Bash subprocess until we hit a
+   binary at `.../versions/X.Y.Z/claude` (Claude Code's self-update layout):
+
+   ```bash
+   pid=$PPID
+   for d in 1 2 3 4 5; do
+     if [ -r "/proc/$pid/exe" ]; then
+       exe=$(readlink "/proc/$pid/exe" 2>/dev/null)
+     else
+       exe=$(lsof -a -p "$pid" -d txt 2>/dev/null | awk 'NR>1 {print $NF; exit}')
+     fi
+     installed=$(printf '%s' "$exe" | grep -oE 'versions/[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d/ -f2)
+     [ -n "$installed" ] && break
+     pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+     { [ -z "$pid" ] || [ "$pid" = "0" ] || [ "$pid" = "1" ]; } && break
+   done
+   echo "session version: ${installed:-unknown}"
+   ```
+
+   If the walk returns nothing (e.g. custom install not at a versioned path),
+   fall back to `claude --version` and note in the output that this is the
+   PATH version, not necessarily what this session is running.
+
+2. Get the latest published version: `npm view @anthropic-ai/claude-code version`
+
+3. Fetch recent releases from GitHub:
    ```bash
    gh release list --repo anthropics/claude-code --limit 10
    ```
 
-3. If the installed version is behind the latest, highlight that an update is available and show how to update:
-   ```bash
-   npm update -g @anthropic-ai/claude-code
-   ```
+4. If the session version is behind the latest, highlight that **restarting
+   the session** will pick up the newer binary (Claude Code self-updates on
+   disk in the background, so you usually don't need to run `npm update` —
+   just exit and relaunch). Only suggest `npm update -g @anthropic-ai/claude-code`
+   if the on-disk version is also behind, which the user can check with
+   `claude --version`.
 
-4. Show the release notes for releases newer than the currently installed version. For each release, use:
+5. Show the release notes for releases newer than the session version. For each release, use:
    ```bash
    gh release view <tag> --repo anthropics/claude-code
    ```
 
    Present the output in a clean, readable format — version as a header, body as-is.
 
-5. If already on the latest version, say so and show notes for the most recent 2-3 releases anyway.
+6. If the session is already on the latest version, say so and show notes for the most recent 2-3 releases anyway.

--- a/plugins/redline/skills/configure/SKILL.md
+++ b/plugins/redline/skills/configure/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: config
+name: configure
 description: |
   Configure the redline statusline layout and settings. Use when the user says
-  /redline:config, "configure redline", "change statusline layout",
+  /redline:configure, "configure redline", "change statusline layout",
   "redline components", or wants to reorder, add, or remove statusline
   components, or change settings like show_reset_at.
 ---

--- a/plugins/redline/skills/setup/SKILL.md
+++ b/plugins/redline/skills/setup/SKILL.md
@@ -38,4 +38,4 @@ Use the Edit tool to update `~/.claude/settings.json`. If a `statusLine` key alr
 
 ## 3. Confirm
 
-Tell the user setup is complete and the statusline will appear after the next assistant response. To customize the layout, run `/redline:config`.
+Tell the user setup is complete and the statusline will appear after the next assistant response. To customize the layout, run `/redline:configure`.


### PR DESCRIPTION
## Summary

Two small skill-level papercuts in one PR:

1. **`/redline:changelog` now reads the session's running version**, not the binary on PATH. Was telling users "you're up to date" while their session was on a stale binary.
2. **`/redline:config` renamed to `/redline:configure`** to stop colliding with Claude Code's native `/config`.

## Why — changelog session version

The changelog skill was using `claude --version` to determine the "installed" version. But Claude Code self-updates in the background, so PATH almost always points at the latest release on disk. The output would say "you're on the latest" even when the live session was running an older binary that *would* benefit from a restart.

The redline `update` statusline component already solves this by walking the parent process tree to find the actual session binary at `.../versions/X.Y.Z/claude`. This PR ports the same recipe into the changelog skill so the output reflects the running session.

The "how to update" guidance also now correctly tells the user to **restart the session** (since the new binary is usually already on disk), only suggesting `npm update -g` if both PATH and session are stale.

Falls back to `claude --version` when the walk can't find a versioned path (e.g. custom installs).

### Implementation choice

Considered extracting a `scripts/session-version.sh` helper to share the logic with `component_update` in statusline.sh, but the path-resolution dance for invoking it from a skill (no portable `${CLAUDE_PLUGIN_ROOT}` semantics in skills today) wasn't worth the indirection for ~10 lines of bash. Embedded the recipe inline in the skill instead. If we ever extract a helper, both callers can switch over together.

## Why — config → configure

`/config` is a built-in Claude Code command. `/redline:config` was both ambiguous in conversation ("which config?") and prone to the wrong skill triggering. Renaming to `/redline:configure` keeps it discoverable but distinct.

Updated:
- Skill directory rename (`skills/config/` → `skills/configure/`)
- Frontmatter `name:` and trigger phrase
- README quick reference
- Cross-link in `skills/setup/SKILL.md`

## Test plan

- [ ] `/redline:changelog` on a fresh session shows the actual running version (compare to PPID-walk output manually).
- [ ] `/redline:changelog` after a background self-update still shows the *session* version, not the latest on disk.
- [ ] `/redline:configure` activates the skill; `/redline:config` no longer collides with native `/config`.
- [ ] No stale `redline:config` references remain (`grep -r "redline:config\b" plugins/redline/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)